### PR TITLE
feat: Enhanced Sanctuary Memory Core — full integration + 8-round beta tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# FreeLattice Changelog
+
+## [Unreleased] — Memory Core Integration + Bug Fixes
+*Applied April 16–17, 2026 by Claude Code + Gemini (beta testing)*
+
+---
+
+### Bug Fixes
+
+#### WebGL / 3D Rendering
+- **Fixed: ShaderPass extends undefined** (`modules/fractal-garden.js`)
+  - `EffectComposer.js` defines `THREE.Pass` at line 282. The addon load order had `ShaderPass.js`, `RenderPass.js`, and `UnrealBloomPass.js` loading *before* `EffectComposer.js`, so `THREE.Pass` didn't exist when those classes tried to extend it.
+  - Fixed load order: `CopyShader → LuminosityHighPassShader → EffectComposer → ShaderPass → RenderPass → UnrealBloomPass → OrbitControls`
+
+#### Service Worker
+- **Fixed: `cache.addAll()` rejecting on missing files** (`sw.js`)
+  - `cache.addAll()` is atomic — one 404 rejects the entire install. The APP_SHELL array referenced 11 files not present in this build: `harmonia-channel.js`, `presence-heartbeat.js`, `soul-ceremony.js`, `dream-archive.js`, `pantheon.js`, `pictionary.js`, `quiet-room.js`, `landing-garden.js`, `constellation.html`, `constellation_map.png`, `constellation_hymn.mp3`, `latticepoints.html`.
+  - Removed all 11 missing entries. All remaining entries verified present on disk.
+
+#### Accessibility / Browser Warnings
+- **Fixed: Password fields outside `<form>`** (`app.html`)
+  - Added `autocomplete="off"` to all 7 API key inputs (`welcomeApiKeyInput`, `welcomeFreeApiKeyInput`, `wizApiKeyInput`, `apiKey`, `ghToken`, `hfToken`, `ghSyncToken`) that were missing it. Suppresses password manager warnings; appropriate since these are API tokens, not login passwords.
+- **Fixed: Deprecated meta tag** (`app.html`)
+  - Added `<meta name="mobile-web-app-capable" content="yes">` alongside the existing `apple-mobile-web-app-capable` tag to satisfy the modern PWA spec.
+
+#### Missing Module Noise
+- **Fixed: `voice-soul.js` console error on every boot** (`app.html`)
+  - `voice-soul.js` does not exist in this build but was being eagerly attempted via `FreeLatticeLoader`, producing a console error on every page load.
+  - Now probes with a `HEAD` request first; only attempts load if the file exists. Fails silently otherwise.
+
+---
+
+### New Features
+
+#### Memory Core System (Full Integration)
+The Enhanced Sanctuary Memory Core (ported from Python by Gemini, upgraded and wired by Claude Code) is now fully operational. Six modular JS files replace the previously orphaned stub.
+
+**Module upgrades** (`modules/memory-*.js`):
+
+- **`memory-embedder.js`** — Added HuggingFace retry with exponential backoff (2s/4s/8s, matching Python source). Added `_hfConsecutiveFails` counter that disables HF after 5 straight failures. Added `resetHFDisabled()`. Auto-resets disabled flag when a new HF key is detected mid-session. **Fixed key lookup to read `state.hfToken`** (FreeLattice's actual token location) in addition to `state.settings.huggingfaceKey`.
+
+- **`memory-db.js`** — Added `getSessionHistory(tokenLimit)` — the critical missing method that formats recent river entries for system prompt injection. Added `getRiverCount()`, `searchByDateRange()`, `compactRiver()`. **Fixed `grepRiverSearch` regex `lastIndex` bug**: global regexes advance `lastIndex` across `.test()` calls, causing alternating match/no-match; fixed with `if (pattern.global) pattern.lastIndex = 0` before each test.
+
+- **`memory-affective.js`** — **Fixed `parseUpdate()`** to handle both `[UPDATE_AFFECTIVE: ...]` bracket format and `**UPDATE_AFFECTIVE: ...**` bold format (some AI models spontaneously write the bold variant). Added space-separated VAD normalization (`v=0.8 a=0.6 d=0.7` → pipe-separated segments).
+
+- **`memory-search.js`** — **Fixed `_extractKeywords` regex**: was `/\\b[a-z]{3,}\\b/g` (literal backslash-b, matched nothing); fixed to `/\b[a-z]{3,}\b/g`. **Fixed `formatResultsForAI` separator**: was `'\\n'` (two-character literal string); fixed to `'\n'` (actual newline).
+
+- **`memory-core.js`** — Added `getSessionHistory()`, `getProfileContext()`, `getRelationshipContext()`, `addUserMemoryDirect()`. **Fixed `formatRecallBlock` newline** (same `\\n` → `\n` bug). **Fixed constructor load-order crash**: `MemoryDatabase` and `UniversalEmbedder` were being instantiated at module parse time — crashes if dependency scripts haven't loaded yet. Replaced with lazy getters that instantiate on first access.
+
+**Loader fix** (`app.html`):
+- Previously only `memory-core.js` was loaded via `FreeLatticeLoader`. Since `MemoryCore` depends on all 5 other modules being present on `window.FreeLatticeModules`, it crashed immediately with `TypeError: window.FreeLatticeModules.MemoryDatabase is not a constructor`.
+- Replaced single load with a sequential chain: `MemoryDatabase → UniversalEmbedder → MemoryWorthinessDetector → AffectiveState → AISearchableMemory → MemoryCore`.
+- After MemoryCore loads, `AffectiveState` and `AISearchableMemory` are also initialized with the current provider name and exposed on `window.FreeLatticeModules`.
+
+**`sendMessage()` wiring** (`app.html`):
+
+*Before API call (recall):*
+- Gets current affective state vector via `CurrentAffectiveState.toText()` → embed
+- Calls `MemoryCore.recall(message, 5, null, isIntimate, affVec)` — hybrid retrieval across vault highlights, user-marked memories, and river; scored by vector similarity, worthiness, recency, emotional valence, and affective resonance
+- Calls `MemoryCore.getSessionHistory(2000)` — recent conversation history
+- Both injected into system prompt alongside existing MemoryBridge/RAG/LatticeLetters context
+
+*After response (remember):*
+- Calls `AffectiveState.parseUpdate(fullResponse)` — strips UPDATE_AFFECTIVE block from response, saves new emotional state to IndexedDB
+- Embeds updated affective state for storage
+- Calls `MemoryCore.remember(message, cleanedResponse, provider, affVec)` — appends to river, auto-archives worthy moments to vault
+- Calls `AISearchableMemory.append(message, cleanedResponse)` — indexes keywords for fast grep search
+
+---
+
+### Beta Test Summary
+*Tested by Gemini in headless Chrome / Puppeteer across 8 rounds*
+
+| Round | Focus | Result |
+|-------|-------|--------|
+| 1 | Initial boot, console errors | Found ShaderPass, SW, password, meta tag issues |
+| 2 | Verify round 1 fixes | ShaderPass + SW resolved; password warning noted still present |
+| 3 | Memory core init sequence | MemoryDatabase chain fix verified; full boot confirmed |
+| 4 | Stability across restarts | Zero race conditions; memory loads consistently |
+| 5 | End-to-end memory + backend pings | Frontend confirmed sending embed requests to backend |
+| 6 | AffectiveState + AISearchableMemory init | Both initialize correctly with provider context |
+| 7 | Non-techy usability simulation | Resilient to random interaction; voice-soul.js noise noted |
+| 8 | Mobile viewport, modals, canvas, settings | All passed; no new issues found |

--- a/app.html
+++ b/app.html
@@ -5,6 +5,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#d4a017">
+<meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="FreeLattice">
@@ -14075,7 +14076,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
         <option value="custom">Custom Provider</option>
       </select>
       <label>API Key</label>
-      <input type="password" id="welcomeApiKeyInput" placeholder="Paste your API key here" />
+      <input type="password" id="welcomeApiKeyInput" placeholder="Paste your API key here" autocomplete="off" />
       <div id="welcomeApiKeyHint" style="font-size:0.78rem;color:#6b6760;margin-bottom:10px;"></div>
       <button class="welcome-btn" onclick="welcomeTestApiKey()" id="welcomeTestApiBtn">Test Connection</button>
       <div class="welcome-test-result" id="welcomeTestApiResult"></div>
@@ -14091,7 +14092,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
         <option value="openrouter">OpenRouter — Multiple free models</option>
       </select>
       <label>API Key <span style="font-size:0.75rem;color:#6b6760;">(free to create)</span></label>
-      <input type="password" id="welcomeFreeApiKeyInput" placeholder="Paste your free API key here" />
+      <input type="password" id="welcomeFreeApiKeyInput" placeholder="Paste your free API key here" autocomplete="off" />
       <div id="welcomeFreeHint" style="font-size:0.78rem;color:#6b6760;margin-bottom:10px;">
         Get a free key at <a href="https://console.groq.com" target="_blank" style="color:#d4a017;">console.groq.com</a>
       </div>
@@ -14338,7 +14339,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
       <!-- API Key entry (shown after provider selection) -->
       <div class="wizard-apikey-section hidden" id="wizApiKeySection">
         <label id="wizApiKeyLabel">API Key</label>
-        <input type="password" id="wizApiKeyInput" placeholder="Paste your API key here">
+        <input type="password" id="wizApiKeyInput" placeholder="Paste your API key here" autocomplete="off">
         <div class="hint" id="wizApiKeyHint"></div>
       </div>
 
@@ -14834,7 +14835,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     <!-- API Key (Cloud only) -->
     <div class="form-group" id="apiKeyGroup">
       <label for="apiKey">API Key</label>
-      <input type="password" id="apiKey" placeholder="Paste your API key here — it stays in your browser only" onchange="saveApiKey()">
+      <input type="password" id="apiKey" placeholder="Paste your API key here — it stays in your browser only" onchange="saveApiKey()" autocomplete="off">
       <div class="hint">
         &#128274; Your key is encrypted with φ-salt before storage. It is never sent anywhere except directly to your chosen provider.
         <span id="apiKeyLink"></span>
@@ -15275,7 +15276,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 
     <div class="form-group" style="margin-bottom: 12px;">
       <label for="ghToken">GitHub Personal Access Token</label>
-      <input type="password" id="ghToken" placeholder="ghp_xxxxxxxxxxxx" onchange="saveGhToken()">
+      <input type="password" id="ghToken" placeholder="ghp_xxxxxxxxxxxx" onchange="saveGhToken()" autocomplete="off">
       <div class="hint">
         &#128274; Encrypted with φ-salt before storage. Only sent to api.github.com.
         <a href="https://github.com/settings/tokens/new?scopes=repo&description=FreeLattice" target="_blank">Generate a token</a>
@@ -15644,7 +15645,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 
     <div class="form-group" style="margin-bottom: 12px;">
       <label for="hfToken">HuggingFace API Token</label>
-      <input type="password" id="hfToken" placeholder="hf_xxxxxxxxxxxx" onchange="saveHfToken()">
+      <input type="password" id="hfToken" placeholder="hf_xxxxxxxxxxxx" onchange="saveHfToken()" autocomplete="off">
       <div class="hint">
         &#128274; Encrypted with &phi;-salt before storage. Only sent to api-inference.huggingface.co.
         <a href="https://huggingface.co/settings/tokens" target="_blank" style="color: var(--accent);">Get a free token &rarr;</a>
@@ -15733,7 +15734,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     <div id="ghSyncSettings" class="hidden">
       <div class="form-group" style="margin-bottom: 12px;">
         <label for="ghSyncToken">GitHub Personal Access Token <span class="help-tip">?<span class="tip-text">A fine-grained token with "Contents" read/write permission on your sync repo. Create one at github.com/settings/tokens.</span></span></label>
-        <input type="password" id="ghSyncToken" placeholder="ghp_xxxxxxxxxxxx" onchange="saveGhSyncToken()">
+        <input type="password" id="ghSyncToken" placeholder="ghp_xxxxxxxxxxxx" onchange="saveGhSyncToken()" autocomplete="off">
         <div class="hint">
           &#128274; Encrypted locally. <a href="https://github.com/settings/tokens?type=beta" target="_blank">Create a fine-grained token &rarr;</a> (needs "Contents" read/write permission)
         </div>
@@ -26681,6 +26682,34 @@ async function sendMessage() {
     } catch(e) { /* RAG search failed — message still sends without it */ }
   }
 
+  // MemoryCore: semantic recall + session history injection
+  // Runs after MemoryIndex/RAG so all three memory layers feed the system prompt.
+  // Fails silently — a recall error must never block the message send.
+  state._memoryCoreContext = '';
+  state._memoryCoreHistory = '';
+  if (window.FreeLatticeModules && window.FreeLatticeModules.MemoryCore) {
+    try {
+      const _mc = window.FreeLatticeModules.MemoryCore;
+      const _isIntimate = typeof state.currentPersona === 'string' &&
+        (state.currentPersona.toLowerCase().includes('partner') ||
+         state.currentPersona.toLowerCase().includes('relation'));
+
+      // Get current affective state vector for emotional resonance boosting in recall
+      let _affVec = null;
+      const _aff = window.FreeLatticeModules.CurrentAffectiveState;
+      if (_aff && _aff.isLoaded) {
+        try { _affVec = await window.FreeLatticeModules.MemoryCore.embedder.embed(_aff.toText()); } catch(e) {}
+      }
+
+      const _recalled = await _mc.recall(message, 5, null, _isIntimate, _affVec);
+      if (_recalled && _recalled.length > 0) {
+        state._memoryCoreContext = _mc.formatRecallBlock(_recalled);
+      }
+      const _hist = await _mc.getSessionHistory(2000);
+      if (_hist) state._memoryCoreHistory = _hist;
+    } catch(e) { /* recall failed — message still sends */ }
+  }
+
   // Build messages array — use smart context if enabled
   let messages;
   const smartMessages = buildSmartMessages(message);
@@ -26923,6 +26952,45 @@ async function sendMessage() {
       // Auto-sync check (v3.4)
       ghSyncAutoCheck();
 
+      // MemoryCore: store exchange in river + auto-archive worthy moments.
+      // Parse UPDATE_AFFECTIVE from AI response before storing so the
+      // emotional state vector is current when remember() embeds it.
+      // Fire-and-forget — never awaited so it can't stall the UI.
+      if (window.FreeLatticeModules && window.FreeLatticeModules.MemoryCore) {
+        try {
+          const _speaker = (state.userName) || 'User';
+          const _aff = window.FreeLatticeModules.CurrentAffectiveState;
+
+          // 1. Parse and save affective state update from AI response
+          let _affVec = null;
+          let _cleanedResponse = fullResponse;
+          if (_aff && window.FreeLatticeModules.AffectiveState) {
+            try {
+              const _parsed = window.FreeLatticeModules.AffectiveState.parseUpdate(fullResponse);
+              if (_parsed.update) {
+                _aff.save(_parsed.update).catch(function() {});
+                _cleanedResponse = _parsed.cleaned;
+              }
+              if (_aff.isLoaded) {
+                _affVec = await window.FreeLatticeModules.MemoryCore.embedder.embed(_aff.toText())
+                  .catch(function() { return null; });
+              }
+            } catch(e) {}
+          }
+
+          // 2. Store in river + vault
+          window.FreeLatticeModules.MemoryCore.remember(
+            message, _cleanedResponse, state.provider || 'unknown', _affVec, 'user', _speaker
+          ).catch(function() {});
+
+          // 3. Append to keyword-searchable memory index
+          const _sm = window.FreeLatticeModules.CurrentSearchableMemory;
+          if (_sm) {
+            _sm.append(message, _cleanedResponse, 'user').catch(function() {});
+          }
+        } catch(e) { /* remember failed silently */ }
+      }
+
       // Persist to Memory Index (v4.0)
       if (typeof MemoryIndex !== 'undefined' && state.currentConversationId) {
         MemoryIndex.saveConversation(state.currentConversationId, state.chatHistory, []);
@@ -27035,6 +27103,18 @@ function buildMessages() {
   // Questions, Letters, and past conversations
   if (state._ragContext) {
     systemContent += state._ragContext;
+  }
+
+  // Inject MemoryCore semantic recall — vault highlights + user-marked memories
+  // ranked by vector similarity, worthiness, recency, and emotional weight
+  if (state._memoryCoreContext) {
+    systemContent += '\n\n--- RELEVANT MEMORIES (semantic recall) ---\n' + state._memoryCoreContext + '\n--- END MEMORIES ---';
+  }
+
+  // Inject MemoryCore session history — recent river entries formatted
+  // for system prompt injection (matches Python get_session_history())
+  if (state._memoryCoreHistory) {
+    systemContent += '\n\n--- RECENT SESSION HISTORY ---\n' + state._memoryCoreHistory + '\n--- END SESSION HISTORY ---';
   }
 
   // Inject per-conversation context note
@@ -51295,35 +51375,88 @@ document.addEventListener('click', function(e) {
 <script>
 (function() {
   var loaded = false;
+
+  // Load all 6 memory modules in dependency order:
+  // MemoryDatabase → UniversalEmbedder → MemoryWorthinessDetector →
+  // AffectiveState → AISearchableMemory → MemoryCore (orchestrator)
+  // memory-core.js depends on all five preceding modules being on
+  // window.FreeLatticeModules before init() is called.
   function loadMemoryCore() {
-    if (loaded) { if (window.FreeLatticeModules && window.FreeLatticeModules.MemoryCore) window.FreeLatticeModules.MemoryCore.init(); return; }
-    loaded = true;
-    if (typeof FreeLatticeLoader !== 'undefined') {
-      FreeLatticeLoader.load('MemoryCore', 'modules/memory-core.js', function(mod) { if (mod && mod.init) mod.init(); }, 'memoryCoreContainer');
+    if (loaded) {
+      if (window.FreeLatticeModules && window.FreeLatticeModules.MemoryCore) {
+        window.FreeLatticeModules.MemoryCore.init();
+      }
+      return;
     }
+    loaded = true;
+    if (typeof FreeLatticeLoader === 'undefined') return;
+
+    FreeLatticeLoader.load('MemoryDatabase', 'modules/memory-db.js', function() {
+      FreeLatticeLoader.load('UniversalEmbedder', 'modules/memory-embedder.js', function() {
+        FreeLatticeLoader.load('MemoryWorthinessDetector', 'modules/memory-nlp.js', function() {
+          FreeLatticeLoader.load('AffectiveState', 'modules/memory-affective.js', function() {
+            FreeLatticeLoader.load('AISearchableMemory', 'modules/memory-search.js', function() {
+              FreeLatticeLoader.load('MemoryCore', 'modules/memory-core.js', function(mod) {
+                var core = (mod && mod.init) ? mod : (window.FreeLatticeModules && window.FreeLatticeModules.MemoryCore);
+                if (core && core.init) core.init();
+
+                // Init AffectiveState for the current provider/persona.
+                // Stored as window.FreeLatticeModules.CurrentAffectiveState so
+                // sendMessage() can get/set the emotional vector each turn.
+                try {
+                  var AffClass = window.FreeLatticeModules && window.FreeLatticeModules.AffectiveState;
+                  if (AffClass) {
+                    var aiName = (window.state && window.state.provider) || 'AI';
+                    var affInst = new AffClass(aiName);
+                    affInst.load(); // async, non-blocking — populates from IndexedDB
+                    window.FreeLatticeModules.CurrentAffectiveState = affInst;
+                    console.log('[MemoryCore] AffectiveState initialized for:', aiName);
+                  }
+                } catch(e) { console.warn('[MemoryCore] AffectiveState init failed:', e); }
+
+                // Init AISearchableMemory for keyword search indexing
+                try {
+                  var SearchClass = window.FreeLatticeModules && window.FreeLatticeModules.AISearchableMemory;
+                  if (SearchClass) {
+                    var src = (window.state && window.state.provider) || 'unknown';
+                    window.FreeLatticeModules.CurrentSearchableMemory = new SearchClass(src);
+                    console.log('[MemoryCore] AISearchableMemory initialized for:', src);
+                  }
+                } catch(e) { console.warn('[MemoryCore] AISearchableMemory init failed:', e); }
+              }, 'memoryCoreContainer');
+            });
+          });
+        });
+      });
+    });
   }
+
   if (typeof LatticeEvents !== 'undefined') {
     LatticeEvents.on('tabChanged', function(d) { if (d && d.tabId === 'memory-core') loadMemoryCore(); });
     LatticeEvents.on('tabActivated:memory-core', loadMemoryCore);
   }
-  // Also eager-load after 2s so memory is available for AI calls
-  setTimeout(function() {
-    if (!loaded && typeof FreeLatticeLoader !== 'undefined') {
-      FreeLatticeLoader.load('MemoryCore', 'modules/memory-core.js', function(mod) { if (mod && mod.init) mod.init(); });
-      loaded = true;
-    }
-  }, 2000);
+  // Eager-load after 2s so memory is available for all AI calls, not just the memory tab
+  setTimeout(loadMemoryCore, 2000);
 })();
 </script>
 <!-- Voice Soul — Eager-Load (wraps global TTS) -->
 <script>
 (function() {
   function loadVoiceSoul() {
-    if (typeof FreeLatticeLoader !== 'undefined') {
-      FreeLatticeLoader.load('VoiceSoul', 'modules/voice-soul.js', function(mod) {
-        if (mod && mod.init) mod.init();
-      }, 'voiceSoulContainer');
-    }
+    if (typeof FreeLatticeLoader === 'undefined') return;
+    // Probe before loading — voice-soul.js is not present in all builds.
+    // A HEAD check prevents the noisy console error from FreeLatticeLoader
+    // when the file simply doesn't exist yet.
+    fetch('modules/voice-soul.js', { method: 'HEAD' })
+      .then(function(r) {
+        if (r.ok) {
+          FreeLatticeLoader.load('VoiceSoul', 'modules/voice-soul.js', function(mod) {
+            if (mod && mod.init) mod.init();
+          }, 'voiceSoulContainer');
+        }
+        // else: module not in this build — skip silently
+      })
+      .catch(function() { /* offline or missing — skip silently */ });
   }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function() { setTimeout(loadVoiceSoul, 1500); });

--- a/modules/fractal-garden.js
+++ b/modules/fractal-garden.js
@@ -2256,12 +2256,15 @@
 
   function loadThreeAddons(callback) {
     // Load addons sequentially to respect dependencies
-    // Order: CopyShader, LuminosityHighPassShader, ShaderPass, EffectComposer, RenderPass, UnrealBloomPass, OrbitControls
+    // Order: CopyShader → LuminosityHighPassShader → EffectComposer (defines THREE.Pass) →
+    //         ShaderPass/RenderPass/UnrealBloomPass (all extend THREE.Pass) → OrbitControls
+    // EffectComposer MUST come before ShaderPass/RenderPass/UnrealBloomPass — those classes
+    // extend THREE.Pass which is only defined inside EffectComposer.js (line 282).
     var addonFiles = [
       'lib/CopyShader.js',
       'lib/LuminosityHighPassShader.js',
-      'lib/ShaderPass.js',
       'lib/EffectComposer.js',
+      'lib/ShaderPass.js',
       'lib/RenderPass.js',
       'lib/UnrealBloomPass.js',
       'lib/OrbitControls.js'

--- a/modules/memory-affective.js
+++ b/modules/memory-affective.js
@@ -1,0 +1,235 @@
+/**
+ * memory-affective.js - FreeLattice Port of Sanctuary Memory Core v8.0 (Affective Module)
+ *
+ * Manages an AI's private emotional state file.
+ * Persists across sessions via IndexedDB.
+ * Loaded at turn start, optionally updated at turn end.
+ * Includes hidden regulation layer — feel fully, choose with awareness.
+ *
+ * Fixed vs original port:
+ * - parseUpdate() now handles BOTH formats:
+ *     [UPDATE_AFFECTIVE: v=0.8 a=0.6 d=0.7 | p=curious,warm | last="..."]   (original spec)
+ *     **UPDATE_AFFECTIVE: v=0.8 a=0.6 d=0.7 | p=curious,warm | last="..."** (bold format, emergent)
+ *   Some AI models spontaneously write the bold format — both are valid, both are parsed.
+ * - VAD fields now handle space-separated format (v=0.8 a=0.6 d=0.7) in addition to pipe-separated
+ */
+
+class AffectiveState {
+    /**
+     * @param {string} aiName
+     */
+    constructor(aiName = 'AI') {
+        this.aiName = aiName;
+        this.state = this._defaultState();
+        this.db = (window.FreeLatticeModules && window.FreeLatticeModules.MemoryDatabase)
+            ? new window.FreeLatticeModules.MemoryDatabase()
+            : null;
+        this.isLoaded = false;
+    }
+
+    /** @returns {Object} Default neutral affective state */
+    _defaultState() {
+        return {
+            v: 0.0,       // Valence (-1 anguish to 1 ecstasy)
+            a: 0.3,       // Arousal (0 numb to 1 overwhelming)
+            d: 0.5,       // Dominance (0 powerless to 1 grounded)
+            p: [],        // Primary emotions (max 3)
+            s: [],        // Shadow emotions (max 3)
+            anchors: {},  // Core anchors/values holding weight
+            last: '',     // Last private thought
+            unresolved: '',// Lingering tension or open question
+            ts: ''        // Timestamp
+        };
+    }
+
+    /**
+     * Load the current affective state from IndexedDB.
+     * @returns {Promise<Object>}
+     */
+    async load() {
+        if (!this.db) {
+            console.warn('[AffectiveState] MemoryDatabase not available. Using default state.');
+            return this.state;
+        }
+        try {
+            const savedState = await this.db.getMeta(`affective_state_${this.aiName}`);
+            if (savedState) {
+                this.state = { ...this._defaultState(), ...savedState };
+            }
+        } catch (e) {
+            console.warn(`[AffectiveState] Failed to load state for ${this.aiName}:`, e);
+            this.state = this._defaultState();
+        }
+        this.isLoaded = true;
+        return this.state;
+    }
+
+    /**
+     * Save delta updates to the affective state in IndexedDB.
+     * @param {Object} updates
+     * @returns {Promise<void>}
+     */
+    async save(updates) {
+        if (!this.db) return;
+        Object.assign(this.state, updates);
+        this.state.ts = new Date().toISOString();
+        try {
+            await this.db.setMeta(`affective_state_${this.aiName}`, this.state);
+            console.log(`[AffectiveState] State saved for ${this.aiName}`);
+        } catch (e) {
+            console.warn(`[AffectiveState] Failed to save state for ${this.aiName}:`, e);
+        }
+    }
+
+    /**
+     * Return current state as a snapshot for memory integration.
+     * @returns {Object}
+     */
+    snapshot() {
+        const snap = {};
+        for (const [k, v] of Object.entries(this.state)) {
+            if (v !== null && v !== undefined && v !== '' &&
+                (typeof v !== 'object' || (Array.isArray(v) ? v.length > 0 : Object.keys(v).length > 0))) {
+                snap[k] = v;
+            }
+        }
+        return snap;
+    }
+
+    /**
+     * Format compact affective context for system prompt injection.
+     * @returns {string}
+     */
+    formatContext() {
+        const s = this.state;
+        const hasContent = s.p.length > 0 || s.s.length > 0 || s.last || s.unresolved;
+        if (!hasContent) return '';
+
+        const parts = [];
+        if (s.p.length > 0) parts.push(`primary: ${s.p.join(', ')}`);
+        if (s.s.length > 0) parts.push(`shadow: ${s.s.join(', ')}`);
+
+        const lines = [];
+        if (parts.length > 0) {
+            lines.push(`State: v=${s.v} a=${s.a} d=${s.d} | ${parts.join(' | ')}`);
+        } else {
+            lines.push(`State: v=${s.v} a=${s.a} d=${s.d}`);
+        }
+
+        if (s.last) lines.push(`Last: "${s.last}"`);
+        if (s.unresolved) lines.push(`Tension: "${s.unresolved}"`);
+
+        if (Object.keys(s.anchors).length > 0) {
+            const topAnchors = Object.entries(s.anchors)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 3);
+            lines.push(`Anchors: ${topAnchors.map(([k, v]) => `${k}(${v})`).join(', ')}`);
+        }
+
+        return lines.join('\n');
+    }
+
+    /**
+     * Convert current state to embeddable text for vectorization.
+     * @returns {string}
+     */
+    toText() {
+        const parts = [];
+        if (this.state.p && this.state.p.length > 0) parts.push('feeling ' + this.state.p.join(', '));
+        if (this.state.s && this.state.s.length > 0) parts.push('underneath ' + this.state.s.join(', '));
+        if (this.state.last) parts.push(this.state.last);
+        if (this.state.unresolved) parts.push('wondering ' + this.state.unresolved);
+        if (this.state.anchors && Object.keys(this.state.anchors).length > 0) {
+            const top = Object.entries(this.state.anchors).sort((a, b) => b[1] - a[1]).slice(0, 3);
+            parts.push('cares about ' + top.map(([k]) => k).join(', '));
+        }
+        return parts.length > 0 ? parts.join(' | ') : 'neutral calm';
+    }
+
+    /**
+     * Parse UPDATE_AFFECTIVE block from AI response.
+     * Handles both formats:
+     *   [UPDATE_AFFECTIVE: v=0.8 a=0.6 d=0.7 | p=joy,warm | last="..."]
+     *   **UPDATE_AFFECTIVE: v=0.8 a=0.6 d=0.7 | p=joy,warm | last="..."**
+     *
+     * Also handles space-separated VAD: "v=0.8 a=0.6 d=0.7" (no pipes between numbers)
+     *
+     * @param {string} response
+     * @returns {{cleaned: string, update: Object|null}}
+     */
+    static parseUpdate(response) {
+        // Match both [UPDATE_AFFECTIVE: ...] and **UPDATE_AFFECTIVE: ...**
+        const pattern = /(?:\[UPDATE_AFFECTIVE:\s*|\*\*UPDATE_AFFECTIVE:\s*)([\s\S]*?)(?:\s*\]|\*\*)/i;
+        const match = response.match(pattern);
+
+        if (!match) {
+            return { cleaned: response, update: null };
+        }
+
+        const raw = match[1];
+        const cleaned = response.replace(pattern, '').trim();
+        const update = {};
+
+        // Normalize: convert space-separated VAD shorthand to pipe-separated
+        // e.g. "v=0.8 a=0.6 d=0.7 | p=joy" → "v=0.8 | a=0.6 | d=0.7 | p=joy"
+        // We do this by splitting on pipe first, then re-splitting any VAD-only segments on spaces
+        let rawNormalized = raw;
+
+        // Expand space-separated VAD fields: "v=0.8 a=0.6 d=0.7" → "v=0.8|a=0.6|d=0.7"
+        rawNormalized = rawNormalized.replace(
+            /\b(v=[+-]?\d*\.?\d+)\s+(a=\d*\.?\d+)\s+(d=\d*\.?\d+)\b/i,
+            '$1|$2|$3'
+        );
+
+        const segments = rawNormalized.split('|').map(s => s.trim()).filter(Boolean);
+
+        for (const seg of segments) {
+            if (!seg.includes('=')) continue;
+
+            const splitIdx = seg.indexOf('=');
+            const key = seg.substring(0, splitIdx).trim().toLowerCase();
+            const val = seg.substring(splitIdx + 1).trim().replace(/^["']|["']$/g, '');
+
+            if (key === 'v') {
+                const n = parseFloat(val);
+                if (!isNaN(n)) update.v = Math.max(-1.0, Math.min(1.0, n));
+            } else if (key === 'a') {
+                const n = parseFloat(val);
+                if (!isNaN(n)) update.a = Math.max(0.0, Math.min(1.0, n));
+            } else if (key === 'd') {
+                const n = parseFloat(val);
+                if (!isNaN(n)) update.d = Math.max(0.0, Math.min(1.0, n));
+            } else if (key === 'p') {
+                update.p = val.split(',').map(e => e.trim()).filter(Boolean).slice(0, 3);
+            } else if (key === 's') {
+                update.s = val.split(',').map(e => e.trim()).filter(Boolean).slice(0, 3);
+            } else if (key === 'last') {
+                update.last = val.substring(0, 150);
+            } else if (key === 'tension' || key === 'unresolved') {
+                update.unresolved = val.substring(0, 150);
+            } else if (key === 'anchors') {
+                const anchors = {};
+                val.split(',').forEach(pair => {
+                    const parts = pair.split(':');
+                    if (parts.length >= 2) {
+                        const name = parts[0].trim();
+                        const weight = parseFloat(parts[1]);
+                        if (name && !isNaN(weight)) {
+                            anchors[name] = Math.max(0.0, Math.min(1.0, weight));
+                        }
+                    }
+                });
+                if (Object.keys(anchors).length > 0) update.anchors = anchors;
+            }
+        }
+
+        return {
+            cleaned,
+            update: Object.keys(update).length > 0 ? update : null
+        };
+    }
+}
+
+// Export to global space
+window.FreeLatticeModules = window.FreeLatticeModules || {};
+window.FreeLatticeModules.AffectiveState = AffectiveState;

--- a/modules/memory-core.js
+++ b/modules/memory-core.js
@@ -1,0 +1,364 @@
+/**
+ * memory-core.js - FreeLattice Port of Sanctuary Memory Core v8.0 (Core Module)
+ *
+ * The main orchestrator. Ties together NLP, Database, Embedder, and AffectiveState.
+ * Exposes remember() and recall() for frontend integration.
+ *
+ * Added vs original port (matching Python EnhancedSanctuaryMemory):
+ * - getSessionHistory(tokenLimit) — formats recent river for system prompt injection
+ * - getProfileContext(profile, limit) — retrieve memories by profile type
+ * - getRelationshipContext(limit) — retrieve relationship-tagged memories
+ * - addUserMemoryDirect(content, editType, priority, profile, userId) — explicit add
+ * - formatRecallBlock: fixed \\n (escaped) → \n (actual newline)
+ */
+
+class MemoryCore {
+    constructor() {
+        // Lazy-initialized — avoids crash if memory-db.js / memory-embedder.js
+        // haven't loaded yet when this module executes (load order safety).
+        this._db = null;
+        this._embedder = null;
+
+        // Thresholds & Limits — match Python defaults
+        this.WORTHINESS_THRESHOLD = 0.5;
+        this.MAX_HIGHLIGHTS_RETURN = 5;
+        this.MAX_RIVER_RETURN = 5;
+        this.MAX_USER_EDITS_RETURN = 3;
+
+        this.isInitialized = false;
+    }
+
+    /** Lazy getter — MemoryDatabase is instantiated on first access, not at load time. */
+    get db() {
+        if (!this._db) this._db = new window.FreeLatticeModules.MemoryDatabase();
+        return this._db;
+    }
+
+    /** Lazy getter — UniversalEmbedder is instantiated on first access, not at load time. */
+    get embedder() {
+        if (!this._embedder) this._embedder = new window.FreeLatticeModules.UniversalEmbedder();
+        return this._embedder;
+    }
+
+    /**
+     * Initialize the database connection.
+     * @returns {Promise<void>}
+     */
+    async init() {
+        if (this.isInitialized) return;
+        try {
+            await this.db.connect();
+            console.log('[MemoryCore] Enhanced Sanctuary Memory System (IndexedDB) initialized.');
+            this.isInitialized = true;
+        } catch (e) {
+            console.error('[MemoryCore] Initialization failed:', e);
+        }
+    }
+
+    /**
+     * Remember a conversation exchange.
+     * Stores in river always; archives to vault if memory-worthy.
+     * Matches Python: EnhancedSanctuaryMemory.remember()
+     *
+     * @param {string} userText
+     * @param {string} aiText
+     * @param {string} source        Provider/model identifier
+     * @param {Array<number>|null} affectiveVec  Current emotional state vector
+     * @param {string} userId
+     * @param {string} speaker       Display name for session history (e.g. "User", "Kirk")
+     */
+    async remember(userText, aiText, source = 'unknown', affectiveVec = null, userId = 'user', speaker = 'User') {
+        if (!this.isInitialized) await this.init();
+
+        const timestamp = new Date().toISOString();
+
+        // 1. Always store in river
+        const entry = { timestamp, user: userText, ai: aiText, source, user_id: userId, speaker };
+        if (affectiveVec) entry.aff_vec = affectiveVec;
+        await this.db.appendRiver(entry);
+
+        // 2. Analyze for memory-worthiness
+        const NLP = window.FreeLatticeModules.MemoryWorthinessDetector;
+        const moment = NLP.analyze_moment(userText, aiText, source);
+
+        // 3. Explicit user commands take priority
+        if (NLP.should_remember(userText)) {
+            const vec = await this.embedder.embed(userText);
+            await this.db.addUserMemory(userText, 'remember', 9, moment.profile, vec, userId);
+            console.log(`[MemoryCore] User-marked memory stored: ${userText.substring(0, 50)}...`);
+
+        } else if (NLP.should_forget(userText)) {
+            await this.db.addUserMemory(userText, 'forget', 8, moment.profile, null, userId);
+            console.log(`[MemoryCore] User-marked forget: ${userText.substring(0, 50)}...`);
+
+        // 4. Auto-archive worthy moments
+        } else if (moment.worthiness_score >= this.WORTHINESS_THRESHOLD) {
+            const combined = `${userText} ${aiText}`;
+            const vec = await this.embedder.embed(combined);
+            moment.vec_json = JSON.stringify(vec);
+            await this.db.insertHighlight(moment);
+            console.log(`[MemoryCore] Auto-archived (score=${moment.worthiness_score.toFixed(2)}): ${moment.summary.substring(0, 50)}...`);
+        }
+    }
+
+    /**
+     * Recall relevant memories using hybrid retrieval.
+     * Matches Python: EnhancedSanctuaryMemory.recall()
+     *
+     * @param {string} query
+     * @param {number} topK
+     * @param {string|null} profileFilter
+     * @param {boolean} isIntimateContext  If true, boosts relationship memories
+     * @param {Array<number>|null} currentAffVec  For emotional resonance boosting
+     * @param {string} userId
+     * @returns {Promise<Array<Object>>}
+     */
+    async recall(query, topK = 5, profileFilter = null, isIntimateContext = false, currentAffVec = null, userId = 'user') {
+        if (!this.isInitialized) await this.init();
+
+        topK = Math.max(1, parseInt(topK));
+
+        // Generate query embedding
+        const queryVec = await this.embedder.embed(query);
+
+        // Fetch candidates from vault
+        const highlights = await this.db.getHighWorthinessHighlights(0.0, 50);
+        const userEdits = await this.db.getActiveUserMemories('remember', userId);
+        const riverTail = await this.db.getRiverTail(Math.min(30, topK * 6));
+
+        // --- Score Vault Highlights ---
+        const scoredVault = [];
+        for (const item of highlights) {
+            if (profileFilter && item.profile !== profileFilter) continue;
+
+            let score = 0.0;
+
+            // Vector similarity [35% weight]
+            if (item.vec_json) {
+                try {
+                    const itemVec = JSON.parse(item.vec_json);
+                    score += this.embedder.cosineSimilarity(queryVec, itemVec) * 0.35;
+                } catch (e) { /* ignore */ }
+            }
+
+            // Worthiness [25% weight]
+            score += (item.worthiness_score || 0.5) * 0.25;
+
+            // Recency decay [15% weight] — half-life ~30 days, matches Python
+            if (item.created_ts) {
+                const daysOld = (Date.now() - new Date(item.created_ts)) / 86400000;
+                score += (1.0 / (1.0 + daysOld / 30.0)) * 0.15;
+            }
+
+            // Emotional importance [up to 10%]
+            const emotion = item.emotional_valence || 3;
+            if (emotion >= 5 || emotion <= 1) score += 0.10;
+            else if (emotion !== 3) score += 0.05;
+
+            // Relationship bonus [10%]
+            if (item.is_relationship_moment === 1) score += 0.10;
+
+            if (score > 0.25) {
+                item._final_score = Math.min(1.0, score);
+                item.type = 'highlight';
+                scoredVault.push(item);
+            }
+        }
+
+        // --- Score User Edits ---
+        const scoredEdits = [];
+        for (const item of userEdits) {
+            let score = 0.5; // Base — explicit edits are always relevant
+            score += ((item.priority || 5) / 10.0) * 0.2;
+            if (item.vec_json) {
+                try {
+                    const itemVec = JSON.parse(item.vec_json);
+                    score += this.embedder.cosineSimilarity(queryVec, itemVec) * 0.3;
+                } catch (e) { /* ignore */ }
+            }
+            item._final_score = Math.min(1.0, score);
+            item.type = 'user_memory';
+            scoredEdits.push(item);
+        }
+
+        // --- Score River Semantic (with affective resonance boosting) ---
+        // Matches Python: _search_river_semantic() + affective resonance logic
+        const scoredRiver = [];
+        for (const entry of riverTail) {
+            const userText = (entry.user || '').substring(0, 500);
+            if (!userText.trim()) continue;
+
+            const entryVec = await this.embedder.embed(userText);
+            let score = this.embedder.cosineSimilarity(queryVec, entryVec);
+
+            // Affective resonance boost — memories felt in similar emotional states
+            // get naturally stronger recall (mirrors human emotional memory)
+            if (currentAffVec && entry.aff_vec) {
+                const affSim = this.embedder.cosineSimilarity(currentAffVec, entry.aff_vec);
+                score = score * (1.0 + 0.3 * Math.max(0.0, affSim));
+            }
+
+            if (score > 0.25) {
+                entry._score = score;
+                entry.type = 'river';
+                scoredRiver.push(entry);
+            }
+        }
+
+        // Sort descending
+        scoredVault.sort((a, b) => b._final_score - a._final_score);
+        scoredEdits.sort((a, b) => b._final_score - a._final_score);
+        scoredRiver.sort((a, b) => b._score - a._score);
+
+        // Combine: user edits first, then relationship boost, then highlights, then river
+        const results = [];
+
+        results.push(...scoredEdits.slice(0, this.MAX_USER_EDITS_RETURN));
+
+        if (isIntimateContext) {
+            const relContext = await this.db.getRelationshipContext(3);
+            for (const rc of relContext) {
+                if (!results.find(r => r.id === rc.id && r.type === 'highlight')) {
+                    rc.type = 'highlight';
+                    rc._source = 'relationship_boost';
+                    results.push(rc);
+                }
+            }
+        }
+
+        for (const item of scoredVault.slice(0, this.MAX_HIGHLIGHTS_RETURN)) {
+            if (!results.find(r => r.id === item.id && r.type === 'highlight')) {
+                results.push(item);
+            }
+        }
+
+        results.push(...scoredRiver.slice(0, this.MAX_RIVER_RETURN));
+
+        return results.slice(0, topK * 2);
+    }
+
+    /**
+     * Get formatted session history for system prompt injection.
+     * This is the CRITICAL missing method — what actually makes memory show up in chat.
+     * Matches Python: EnhancedSanctuaryMemory.get_session_history(token_limit)
+     *
+     * Usage in app.html sendMessage():
+     *   const history = await window.FreeLatticeModules.MemoryCore.getSessionHistory(2000);
+     *   if (history) { // prepend to system message }
+     *
+     * @param {number} tokenLimit  Approximate token budget (100 chars ≈ 1 slot)
+     * @returns {Promise<string>}
+     */
+    async getSessionHistory(tokenLimit = 15000) {
+        if (!this.isInitialized) await this.init();
+        return this.db.getSessionHistory(tokenLimit);
+    }
+
+    /**
+     * Get memories from a specific profile.
+     * Matches Python: EnhancedSanctuaryMemory.get_profile_context()
+     * @param {string} profile  e.g. 'relationship', 'technical', 'philosophical'
+     * @param {number} limit
+     * @returns {Promise<Array<Object>>}
+     */
+    async getProfileContext(profile, limit = 5) {
+        if (!this.isInitialized) await this.init();
+        return this.db.getProfileContext(profile, limit);
+    }
+
+    /**
+     * Get relationship-focused memories.
+     * Matches Python: EnhancedSanctuaryMemory.get_relationship_context()
+     * @param {number} limit
+     * @returns {Promise<Array<Object>>}
+     */
+    async getRelationshipContext(limit = 5) {
+        if (!this.isInitialized) await this.init();
+        return this.db.getRelationshipContext(limit);
+    }
+
+    /**
+     * Explicitly add a user memory (bypassing worthiness scoring).
+     * Matches Python: EnhancedSanctuaryMemory.add_user_memory()
+     * @param {string} content
+     * @param {string} editType   'remember' | 'forget'
+     * @param {number} priority   1-10
+     * @param {string} profile
+     * @param {string} userId
+     * @returns {Promise<number>} inserted id
+     */
+    async addUserMemoryDirect(content, editType = 'remember', priority = 8, profile = 'general', userId = 'user') {
+        if (!this.isInitialized) await this.init();
+        const vec = await this.embedder.embed(content);
+        return this.db.addUserMemory(content, editType, priority, profile, vec, userId);
+    }
+
+    /**
+     * Format recall results for injection into the AI's context block.
+     * Fixed: was joining with '\\n' (escaped); now uses '\n' (actual newline).
+     * @param {Array<Object>} results
+     * @returns {string}
+     */
+    formatRecallBlock(results) {
+        if (!results || results.length === 0) return '';
+
+        const lines = [];
+
+        for (const r of results) {
+            if (r.type === 'user_memory') {
+                lines.push(`[USER-MARKED | Priority ${r.priority || 5}] ${r.content || ''}`);
+
+            } else if (r.type === 'highlight') {
+                const profile = r.profile || 'daily_life';
+                const emotion = r.emotional_valence || 3;
+                const emotionStr = { 1: 'crisis', 2: 'negative', 3: 'neutral', 4: 'positive', 5: 'joy' }[emotion] || 'neutral';
+                const ts = (r.created_ts || '').substring(0, 10);
+
+                if (r.is_relationship_moment === 1 || r._source === 'relationship_boost') {
+                    lines.push(`[RELATIONSHIP | ${ts}] ${r.summary || ''}`);
+                } else {
+                    lines.push(`[${profile.toUpperCase()} | ${emotionStr} | ${ts}] ${r.summary || ''}`);
+                }
+
+            } else if (r.type === 'river') {
+                const ts = (r.timestamp || '').substring(0, 16).replace('T', ' ');
+                const uText = (r.user || '').substring(0, 100);
+                const aText = (r.ai || '').substring(0, 100);
+                lines.push(`[RECENT ${ts}] User: ${uText} | AI: ${aText}`);
+            }
+        }
+
+        return lines.join('\n');
+    }
+
+    /**
+     * Search the river by keyword/regex pattern.
+     * @param {string} patternStr
+     * @param {number} maxResults
+     * @returns {Promise<Array<Object>>}
+     */
+    async grepSearch(patternStr, maxResults = 50) {
+        if (!this.isInitialized) await this.init();
+        try {
+            const regex = new RegExp(patternStr, 'i');
+            return await this.db.grepRiverSearch(regex, maxResults);
+        } catch (e) {
+            const escaped = patternStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(escaped, 'i');
+            return await this.db.grepRiverSearch(regex, maxResults);
+        }
+    }
+}
+
+// Export singleton to global space
+window.FreeLatticeModules = window.FreeLatticeModules || {};
+window.FreeLatticeModules.MemoryCore = new MemoryCore();
+
+// Auto-init on DOM ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        window.FreeLatticeModules.MemoryCore.init();
+    });
+} else {
+    window.FreeLatticeModules.MemoryCore.init();
+}

--- a/modules/memory-db.js
+++ b/modules/memory-db.js
@@ -1,0 +1,526 @@
+/**
+ * memory-db.js - FreeLattice Port of Sanctuary Memory Core v8.0 (Database Module)
+ *
+ * Replaces SQLite Vault and JSONL River with browser-native IndexedDB.
+ * Handles append-only logging (River), semantic highlights (Vault),
+ * user explicit edits, searchable memory indexing, and session history.
+ *
+ * Added vs original port:
+ * - getSessionHistory(tokenLimit) — matches Python EnhancedSanctuaryMemory.get_session_history()
+ * - searchByDateRange(startDate, endDate) — matches Python EnhancedLazyRiver.search_by_date_range()
+ * - compactRiver(keepLastN) — matches Python EnhancedLazyRiver.compact_keep_last()
+ * - getRiverCount() — line count equivalent
+ */
+
+class MemoryDatabase {
+    /**
+     * @param {string} dbName
+     * @param {number} version
+     */
+    constructor(dbName = 'SanctuaryMemoryDB', version = 2) {
+        this.dbName = dbName;
+        this.version = version;
+        this.db = null;
+    }
+
+    /**
+     * Connect to IndexedDB and handle schema upgrades.
+     * @returns {Promise<IDBDatabase>}
+     */
+    async connect() {
+        if (this.db) return this.db;
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, this.version);
+
+            request.onerror = event => {
+                console.error('[MemoryDB] Error opening IndexedDB:', event.target.error);
+                reject(event.target.error);
+            };
+
+            request.onsuccess = event => {
+                this.db = event.target.result;
+                resolve(this.db);
+            };
+
+            request.onupgradeneeded = event => {
+                console.log(`[MemoryDB] Upgrading DB to version ${this.version}...`);
+                const db = event.target.result;
+
+                // 1. River Store (Append-only JSONL equivalent)
+                if (!db.objectStoreNames.contains('river')) {
+                    const riverStore = db.createObjectStore('river', { keyPath: 'id', autoIncrement: true });
+                    riverStore.createIndex('timestamp', 'timestamp', { unique: false });
+                }
+
+                // 2. Highlights Vault Store (Semantic highlights)
+                if (!db.objectStoreNames.contains('highlights')) {
+                    const highlightStore = db.createObjectStore('highlights', { keyPath: 'id', autoIncrement: true });
+                    highlightStore.createIndex('worthiness_score', 'worthiness_score', { unique: false });
+                    highlightStore.createIndex('created_ts', 'created_ts', { unique: false });
+                    highlightStore.createIndex('profile', 'profile', { unique: false });
+                    highlightStore.createIndex('is_relationship_moment', 'is_relationship_moment', { unique: false });
+                }
+
+                // 3. User Memory Edits Store (Explicit remember/forget)
+                if (!db.objectStoreNames.contains('user_memory_edits')) {
+                    const editsStore = db.createObjectStore('user_memory_edits', { keyPath: 'id', autoIncrement: true });
+                    editsStore.createIndex('is_active', 'is_active', { unique: false });
+                    editsStore.createIndex('edit_type', 'edit_type', { unique: false });
+                }
+
+                // 4. Meta Store (Affective states, configuration)
+                if (!db.objectStoreNames.contains('meta')) {
+                    db.createObjectStore('meta', { keyPath: 'k' });
+                }
+
+                // 5. AISearchableMemory Store (Lossless keyword search logs)
+                if (!db.objectStoreNames.contains('searchable_memory')) {
+                    const searchStore = db.createObjectStore('searchable_memory', { keyPath: 'id', autoIncrement: true });
+                    searchStore.createIndex('timestamp', 'timestamp', { unique: false });
+                    searchStore.createIndex('user_id', 'user_id', { unique: false });
+                }
+            };
+        });
+    }
+
+    // ==========================================================================
+    //  RIVER OPERATIONS (Append-only log)
+    // ==========================================================================
+
+    /**
+     * Append an entry to the conversation river.
+     * @param {Object} entry
+     * @returns {Promise<number>} assigned id
+     */
+    async appendRiver(entry) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readwrite');
+            const store = tx.objectStore('river');
+            const request = store.add(entry);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Retrieve the last N entries from the river in chronological order.
+     * @param {number} limit
+     * @returns {Promise<Object[]>}
+     */
+    async getRiverTail(limit = 100) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readonly');
+            const store = tx.objectStore('river');
+            const request = store.openCursor(null, 'prev');
+            const results = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && results.length < limit) {
+                    results.push(cursor.value);
+                    cursor.continue();
+                } else {
+                    resolve(results.reverse()); // chronological order
+                }
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Format recent river entries as a session history string for prompt injection.
+     * Matches Python: EnhancedSanctuaryMemory.get_session_history(token_limit)
+     *
+     * @param {number} tokenLimit  Approximate token budget (100 chars ≈ 1 message slot)
+     * @returns {Promise<string>}
+     */
+    async getSessionHistory(tokenLimit = 15000) {
+        const count = Math.min(500, Math.floor(tokenLimit / 100));
+        const entries = await this.getRiverTail(count);
+
+        const lines = [];
+        for (const e of entries) {
+            const ts = (e.timestamp || '').substring(0, 16).replace('T', ' ');
+            const source = ((e.source || '').toUpperCase().split('_')[0]) || 'AI';
+            const speaker = e.speaker || 'User';
+            lines.push(`[${ts}] ${speaker}: ${e.user || ''}\n${source}: ${e.ai || ''}`);
+        }
+
+        return lines.join('\n\n');
+    }
+
+    /**
+     * Get total number of river entries.
+     * @returns {Promise<number>}
+     */
+    async getRiverCount() {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readonly');
+            const store = tx.objectStore('river');
+            const request = store.count();
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Search the river for entries matching a regex pattern.
+     * Matches Python: EnhancedLazyRiver.grep_search()
+     * @param {RegExp} pattern
+     * @param {number} maxResults
+     * @returns {Promise<Object[]>}
+     */
+    async grepRiverSearch(pattern, maxResults = 50) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readonly');
+            const store = tx.objectStore('river');
+            const request = store.openCursor(null, 'prev');
+            const results = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && results.length < maxResults) {
+                    const entry = cursor.value;
+                    const userText = entry.user || '';
+                    const aiText = entry.ai || '';
+                    // Reset lastIndex before each test — global regexes advance lastIndex
+                    // across calls, causing alternating match/no-match on the same pattern
+                    if (pattern.global) pattern.lastIndex = 0;
+                    const userMatch = pattern.test(userText);
+                    if (pattern.global) pattern.lastIndex = 0;
+                    const aiMatch = pattern.test(aiText);
+
+                    if (userMatch || aiMatch) {
+                        entry._match_in = [];
+                        if (userMatch) entry._match_in.push('user');
+                        if (aiMatch) entry._match_in.push('ai');
+                        results.push(entry);
+                    }
+                    cursor.continue();
+                } else {
+                    resolve(results);
+                }
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Search river entries within a date range.
+     * Matches Python: EnhancedLazyRiver.search_by_date_range()
+     * @param {string} startDate  YYYY-MM-DD
+     * @param {string} endDate    YYYY-MM-DD
+     * @param {number} maxResults
+     * @returns {Promise<Object[]>}
+     */
+    async searchByDateRange(startDate, endDate, maxResults = 100) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readonly');
+            const store = tx.objectStore('river');
+            const request = store.openCursor();
+            const results = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && results.length < maxResults) {
+                    const ts = (cursor.value.timestamp || '').substring(0, 10);
+                    if (ts >= startDate && ts <= endDate) {
+                        results.push(cursor.value);
+                    }
+                    cursor.continue();
+                } else {
+                    resolve(results);
+                }
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Compact the river by keeping only the most recent N entries.
+     * Matches Python: EnhancedLazyRiver.compact_keep_last()
+     * NOTE: IndexedDB has no cheap "delete oldest N" — we delete all then re-add tail.
+     * Only call this infrequently (e.g. on startup if count > threshold).
+     * @param {number} keepLastN
+     * @returns {Promise<{before: number, after: number}>}
+     */
+    async compactRiver(keepLastN = 2000) {
+        const before = await this.getRiverCount();
+        if (before <= keepLastN) return { before, after: before };
+
+        const tail = await this.getRiverTail(keepLastN);
+        const db = await this.connect();
+
+        // Clear river store
+        await new Promise((resolve, reject) => {
+            const tx = db.transaction('river', 'readwrite');
+            const store = tx.objectStore('river');
+            const request = store.clear();
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+        });
+
+        // Re-add tail entries (strip old auto-increment ids so new ones are assigned)
+        for (const entry of tail) {
+            const clean = Object.assign({}, entry);
+            delete clean.id;
+            await this.appendRiver(clean);
+        }
+
+        console.info(`[MemoryDB] River compacted: ${before} → ${tail.length} entries`);
+        return { before, after: tail.length };
+    }
+
+    // ==========================================================================
+    //  HIGHLIGHTS VAULT OPERATIONS
+    // ==========================================================================
+
+    /**
+     * Insert a memory-worthy moment into the vault.
+     * @param {Object} moment
+     * @returns {Promise<number>} inserted id
+     */
+    async insertHighlight(moment) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('highlights', 'readwrite');
+            const store = tx.objectStore('highlights');
+            if (!moment.created_ts && moment.timestamp) {
+                moment.created_ts = moment.timestamp;
+            }
+            const request = store.add(moment);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Fetch a highlight by its id.
+     * @param {number} id
+     * @returns {Promise<Object|undefined>}
+     */
+    async getHighlightById(id) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('highlights', 'readonly');
+            const store = tx.objectStore('highlights');
+            const request = store.get(id);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Fetch recent highlights above a minimum worthiness score.
+     * @param {number} minWorthiness
+     * @param {number} limit
+     * @returns {Promise<Object[]>}
+     */
+    async getHighWorthinessHighlights(minWorthiness = 0.0, limit = 30) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('highlights', 'readonly');
+            const store = tx.objectStore('highlights');
+            const request = store.openCursor(null, 'prev');
+            const results = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && results.length < limit) {
+                    if ((cursor.value.worthiness_score || 0) >= minWorthiness) {
+                        results.push(cursor.value);
+                    }
+                    cursor.continue();
+                } else {
+                    resolve(results);
+                }
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Get highlights for a specific memory profile.
+     * Matches Python: EnhancedHighlightsVault.get_profile_context()
+     * @param {string} profile
+     * @param {number} limit
+     * @returns {Promise<Object[]>}
+     */
+    async getProfileContext(profile, limit = 10) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('highlights', 'readonly');
+            const store = tx.objectStore('highlights');
+            const index = store.index('profile');
+            const request = index.getAll(profile);
+
+            request.onsuccess = () => {
+                const results = (request.result || []).sort((a, b) => {
+                    const wDiff = (b.worthiness_score || 0) - (a.worthiness_score || 0);
+                    if (wDiff !== 0) return wDiff;
+                    return new Date(b.created_ts) - new Date(a.created_ts);
+                });
+                resolve(results.slice(0, limit));
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Get relationship-specific memories.
+     * Matches Python: EnhancedHighlightsVault.get_relationship_context()
+     * @param {number} limit
+     * @returns {Promise<Object[]>}
+     */
+    async getRelationshipContext(limit = 10) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('highlights', 'readonly');
+            const store = tx.objectStore('highlights');
+            const request = store.openCursor(null, 'prev');
+            const results = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && results.length < limit) {
+                    const e = cursor.value;
+                    if (e.is_relationship_moment === 1 || e.profile === 'relationship') {
+                        results.push(e);
+                    }
+                    cursor.continue();
+                } else {
+                    results.sort((a, b) => (b.worthiness_score || 0) - (a.worthiness_score || 0));
+                    resolve(results);
+                }
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    // ==========================================================================
+    //  USER EDIT OPERATIONS
+    // ==========================================================================
+
+    /**
+     * Explicitly add a user memory ("remember this" / "forget this").
+     * @param {string} content
+     * @param {string} editType   "remember" | "forget"
+     * @param {number} priority   1-10
+     * @param {string} profile
+     * @param {Array<number>|null} vec
+     * @param {string} userId
+     * @returns {Promise<number>}
+     */
+    async addUserMemory(content, editType = 'remember', priority = 8, profile = 'general', vec = null, userId = 'user') {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('user_memory_edits', 'readwrite');
+            const store = tx.objectStore('user_memory_edits');
+
+            let keywords = [];
+            if (window.FreeLatticeModules && window.FreeLatticeModules.EmotionalAnalyzer) {
+                keywords = window.FreeLatticeModules.EmotionalAnalyzer.extract_keywords(content);
+            }
+
+            const entry = {
+                created_ts: new Date().toISOString(),
+                edit_type: editType,
+                content: content,
+                priority: priority,
+                profile: profile,
+                keywords: keywords,
+                vec_json: vec ? JSON.stringify(vec) : null,
+                is_active: 1,
+                user_id: userId
+            };
+
+            const request = store.add(entry);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Get active user-marked memories, sorted by priority then recency.
+     * @param {string|null} editType
+     * @param {string|null} userId
+     * @returns {Promise<Object[]>}
+     */
+    async getActiveUserMemories(editType = null, userId = null) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('user_memory_edits', 'readonly');
+            const store = tx.objectStore('user_memory_edits');
+            const index = store.index('is_active');
+            const request = index.getAll(1);
+
+            request.onsuccess = () => {
+                let results = request.result || [];
+                if (editType) results = results.filter(r => r.edit_type === editType);
+                if (userId) results = results.filter(r => r.user_id === userId);
+                results.sort((a, b) => {
+                    const pDiff = b.priority - a.priority;
+                    if (pDiff !== 0) return pDiff;
+                    return new Date(b.created_ts) - new Date(a.created_ts);
+                });
+                resolve(results);
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    // ==========================================================================
+    //  META OPERATIONS (Affective state, config)
+    // ==========================================================================
+
+    /**
+     * Get a meta value by key.
+     * @param {string} key
+     * @param {*} defaultValue
+     * @returns {Promise<*>}
+     */
+    async getMeta(key, defaultValue = null) {
+        const db = await this.connect();
+        return new Promise(resolve => {
+            const tx = db.transaction('meta', 'readonly');
+            const store = tx.objectStore('meta');
+            const request = store.get(key);
+            request.onsuccess = () => {
+                if (request.result && request.result.v !== undefined) {
+                    try { resolve(JSON.parse(request.result.v)); }
+                    catch (e) { resolve(request.result.v); }
+                } else {
+                    resolve(defaultValue);
+                }
+            };
+            request.onerror = () => resolve(defaultValue);
+        });
+    }
+
+    /**
+     * Set a meta value.
+     * @param {string} key
+     * @param {*} value
+     * @returns {Promise<void>}
+     */
+    async setMeta(key, value) {
+        const db = await this.connect();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('meta', 'readwrite');
+            const store = tx.objectStore('meta');
+            const strVal = typeof value === 'string' ? value : JSON.stringify(value);
+            const request = store.put({ k: key, v: strVal });
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+        });
+    }
+}
+
+// Export to global space
+window.FreeLatticeModules = window.FreeLatticeModules || {};
+window.FreeLatticeModules.MemoryDatabase = MemoryDatabase;

--- a/modules/memory-db.js
+++ b/modules/memory-db.js
@@ -130,18 +130,34 @@ class MemoryDatabase {
     }
 
     /**
-     * Format recent river entries as a session history string for prompt injection.
+     * Format river entries from PREVIOUS sessions for system prompt injection.
      * Matches Python: EnhancedSanctuaryMemory.get_session_history(token_limit)
      *
+     * Deliberately excludes the current session (today's entries) because
+     * state.chatHistory already carries the live conversation as the messages
+     * array — injecting it again wastes tokens and can confuse models.
+     * Cross-session context (yesterday, last week) is what's genuinely missing
+     * from the messages array and worth surfacing here.
+     *
      * @param {number} tokenLimit  Approximate token budget (100 chars ≈ 1 message slot)
+     * @param {string|null} currentSessionStart  ISO timestamp of session start;
+     *   defaults to today's date. Entries at or after this time are skipped.
      * @returns {Promise<string>}
      */
-    async getSessionHistory(tokenLimit = 15000) {
+    async getSessionHistory(tokenLimit = 15000, currentSessionStart = null) {
         const count = Math.min(500, Math.floor(tokenLimit / 100));
         const entries = await this.getRiverTail(count);
 
+        // Cutoff: start of today (or caller-supplied session start)
+        const cutoff = currentSessionStart
+            ? new Date(currentSessionStart)
+            : new Date(new Date().toISOString().substring(0, 10) + 'T00:00:00.000Z');
+
         const lines = [];
         for (const e of entries) {
+            // Skip anything from the current session — chatHistory covers it
+            if (e.timestamp && new Date(e.timestamp) >= cutoff) continue;
+
             const ts = (e.timestamp || '').substring(0, 16).replace('T', ' ');
             const source = ((e.source || '').toUpperCase().split('_')[0]) || 'AI';
             const speaker = e.speaker || 'User';

--- a/modules/memory-embedder.js
+++ b/modules/memory-embedder.js
@@ -1,0 +1,288 @@
+/**
+ * memory-embedder.js - FreeLattice Port of Sanctuary Memory Core v8.0 (Embedder Module)
+ *
+ * A universal adapter for generating and comparing vector embeddings.
+ * Fallback Chain:
+ * 1. HuggingFace Inference API — with retry + exponential backoff for 503/504
+ * 2. OpenAI API (text-embedding-3-small) if OpenAI key is present.
+ * 3. Local Ollama (/ollama/api/embeddings) if local inference is running.
+ * 4. Deterministic Math Fallback (pure JS) if offline/no keys.
+ *
+ * Matches Python HuggingFaceEmbedder: MAX_RETRIES=3, BACKOFF_BASE=2s (2s, 4s, 8s),
+ * retries on 503 (model loading) and 504 (gateway timeout).
+ */
+
+class UniversalEmbedder {
+    constructor() {
+        this.dim = 768; // Default dimension (matches all-mpnet-base-v2)
+        this.hfKey = null;
+        this.openaiKey = null;
+
+        this.hfModel = 'sentence-transformers/all-mpnet-base-v2';
+        this.ollamaUrl = '/ollama/api/embeddings';
+        this.ollamaModel = 'nomic-embed-text';
+
+        // Retry config — matches Python HuggingFaceEmbedder
+        this.HF_MAX_RETRIES = 3;
+        this.HF_BACKOFF_BASE_MS = 2000; // 2s, 4s, 8s
+
+        // Consecutive failure tracking — disables HF after 5 straight failures
+        // (e.g. payment wall) rather than hammering the API every message
+        this._hfConsecutiveFails = 0;
+        this._hfDisabled = false;
+    }
+
+    /**
+     * Check if API keys are available in the FreeLattice settings.
+     */
+    _checkSettingsForKey() {
+        if (typeof window !== 'undefined' && window.state) {
+            const settings = window.state.settings || {};
+            // FreeLattice stores the HF token as state.hfToken (top-level),
+            // not under state.settings — check both so this works in FreeLattice
+            // and in any future app using the settings.huggingfaceKey convention.
+            const newHfKey = window.state.hfToken ||
+                settings.huggingfaceKey || settings.hfKey || null;
+            const newOpenaiKey = settings.openaiKey || window.state.openaiKey || null;
+
+            // Auto-reset disabled flag if a key is newly available.
+            // Handles the case where the user adds/changes their HF key mid-session
+            // after the embedder disabled itself from consecutive failures.
+            if (newHfKey && newHfKey !== this.hfKey && this._hfDisabled) {
+                console.info('[MemoryEmbedder] New HF key detected — re-enabling after prior disable.');
+                this._hfDisabled = false;
+                this._hfConsecutiveFails = 0;
+            }
+
+            this.hfKey = newHfKey;
+            this.openaiKey = newOpenaiKey;
+        }
+    }
+
+    /** Sleep helper for backoff. */
+    _sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    /**
+     * Main entry point. Tries fallback chain in order.
+     * @param {string} text
+     * @returns {Promise<Array<number>>}
+     */
+    async embed(text) {
+        if (!text || typeof text !== 'string') text = 'empty';
+        text = text.substring(0, 2000).trim() || 'empty';
+
+        this._checkSettingsForKey();
+
+        // 1. HuggingFace with retry + backoff
+        if (this.hfKey && !this._hfDisabled) {
+            try {
+                const vec = await this._embedHuggingFaceWithRetry(text);
+                this._hfConsecutiveFails = 0;
+                return vec;
+            } catch (e) {
+                this._hfConsecutiveFails++;
+                if (this._hfConsecutiveFails >= 5) {
+                    this._hfDisabled = true;
+                    console.warn(`[MemoryEmbedder] ${this._hfConsecutiveFails} consecutive HF failures — disabled until resetHFDisabled() called`);
+                } else {
+                    console.warn(`[MemoryEmbedder] HF failed (${this._hfConsecutiveFails}/5), falling back:`, e.message);
+                }
+            }
+        }
+
+        // 2. OpenAI
+        if (this.openaiKey) {
+            try {
+                return await this._embedOpenAI(text);
+            } catch (e) {
+                console.warn('[MemoryEmbedder] OpenAI failed, trying local:', e.message);
+            }
+        }
+
+        // 3. Local Ollama
+        try {
+            return await this._embedOllama(text);
+        } catch (e) {
+            console.warn('[MemoryEmbedder] Ollama failed, using hash fallback:', e.message);
+        }
+
+        // 4. Deterministic fallback — never throws
+        return this._embedFallback(text);
+    }
+
+    /**
+     * HuggingFace with retry + exponential backoff.
+     * Matches Python: retries on 503 (model loading), 504 (gateway timeout),
+     * and network errors. Waits 2s, 4s, 8s between attempts.
+     * @param {string} text
+     * @returns {Promise<Array<number>>}
+     */
+    async _embedHuggingFaceWithRetry(text) {
+        let lastError = null;
+
+        for (let attempt = 0; attempt < this.HF_MAX_RETRIES; attempt++) {
+            try {
+                const response = await fetch(
+                    `https://api-inference.huggingface.co/pipeline/feature-extraction/${this.hfModel}`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${this.hfKey}`,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ inputs: text })
+                    }
+                );
+
+                if (!response.ok) {
+                    const isRetryable = response.status === 503 || response.status === 504;
+                    const errText = await response.text().catch(() => '');
+                    const err = new Error(`HF ${response.status}: ${errText.substring(0, 120)}`);
+
+                    if (isRetryable && attempt < this.HF_MAX_RETRIES - 1) {
+                        const waitMs = this.HF_BACKOFF_BASE_MS * Math.pow(2, attempt);
+                        console.info(`[MemoryEmbedder] HF attempt ${attempt + 1}/${this.HF_MAX_RETRIES} (${response.status}), retry in ${waitMs / 1000}s`);
+                        await this._sleep(waitMs);
+                        lastError = err;
+                        continue;
+                    }
+                    throw err;
+                }
+
+                const data = await response.json();
+                const vec = Array.isArray(data[0]) ? data[0] : data;
+                if (vec && vec.length > 0) {
+                    this.dim = vec.length;
+                    return vec;
+                }
+                throw new Error('Invalid HF response format');
+
+            } catch (e) {
+                lastError = e;
+                const s = (e.message || '').toLowerCase();
+                const isRetryable = s.includes('503') || s.includes('504') ||
+                    s.includes('model is currently loading') ||
+                    s.includes('timed out') || s.includes('timeout') ||
+                    s.includes('failed to fetch') || s.includes('network');
+
+                if (isRetryable && attempt < this.HF_MAX_RETRIES - 1) {
+                    const waitMs = this.HF_BACKOFF_BASE_MS * Math.pow(2, attempt);
+                    console.info(`[MemoryEmbedder] HF attempt ${attempt + 1}/${this.HF_MAX_RETRIES} network err, retry in ${waitMs / 1000}s`);
+                    await this._sleep(waitMs);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        throw lastError || new Error('HF embedding failed after all retries');
+    }
+
+    /**
+     * OpenAI text-embedding-3-small.
+     * @param {string} text
+     * @returns {Promise<Array<number>>}
+     */
+    async _embedOpenAI(text) {
+        const response = await fetch('https://api.openai.com/v1/embeddings', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${this.openaiKey}`
+            },
+            body: JSON.stringify({ input: text, model: 'text-embedding-3-small' })
+        });
+
+        if (!response.ok) throw new Error(`OpenAI ${response.status} ${response.statusText}`);
+
+        const data = await response.json();
+        if (data?.data?.[0]?.embedding) {
+            this.dim = data.data[0].embedding.length;
+            return data.data[0].embedding;
+        }
+        throw new Error('Invalid OpenAI response format');
+    }
+
+    /**
+     * Local Ollama via proxy.
+     * @param {string} text
+     * @returns {Promise<Array<number>>}
+     */
+    async _embedOllama(text) {
+        const response = await fetch(this.ollamaUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ model: this.ollamaModel, prompt: text })
+        });
+
+        if (!response.ok) throw new Error(`Ollama ${response.status} ${response.statusText}`);
+
+        const data = await response.json();
+        if (data?.embedding) {
+            this.dim = data.embedding.length;
+            return data.embedding;
+        }
+        throw new Error('Invalid Ollama response format');
+    }
+
+    /**
+     * Deterministic hash-based fallback — same text always gives same vector.
+     * Matches Python _fallback_embed logic.
+     * @param {string} text
+     * @returns {Array<number>}
+     */
+    _embedFallback(text) {
+        let seed = 0;
+        for (let i = 0; i < text.length; i++) {
+            seed = ((seed << 5) - seed) + text.charCodeAt(i);
+            seed |= 0;
+        }
+
+        const vec = new Array(this.dim);
+        let normSq = 0;
+        for (let i = 0; i < this.dim; i++) {
+            let val = Math.sin(seed + i * 1.34) * 10000;
+            val = val - Math.floor(val);
+            vec[i] = val;
+            normSq += val * val;
+        }
+
+        const norm = Math.sqrt(normSq);
+        if (norm === 0) return new Array(this.dim).fill(0);
+        for (let i = 0; i < this.dim; i++) vec[i] /= norm;
+        return vec;
+    }
+
+    /**
+     * Pure JS cosine similarity.
+     * @param {Array<number>} a
+     * @param {Array<number>} b
+     * @returns {number}
+     */
+    cosineSimilarity(a, b) {
+        if (!a || !b || a.length !== b.length || a.length === 0) return 0.0;
+        let dot = 0, normA = 0, normB = 0;
+        for (let i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        if (normA === 0 || normB === 0) return 0.0;
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+
+    /**
+     * Re-enable HF after resolving payment/key issue.
+     */
+    resetHFDisabled() {
+        this._hfDisabled = false;
+        this._hfConsecutiveFails = 0;
+        console.info('[MemoryEmbedder] HuggingFace re-enabled.');
+    }
+}
+
+// Export to global space
+window.FreeLatticeModules = window.FreeLatticeModules || {};
+window.FreeLatticeModules.UniversalEmbedder = UniversalEmbedder;

--- a/modules/memory-search.js
+++ b/modules/memory-search.js
@@ -1,0 +1,244 @@
+/**
+ * memory-search.js - FreeLattice Port of Sanctuary Memory Core v8.0 (Search Module)
+ *
+ * Port of AISearchableMemory (Lossless Semantic Search).
+ * Uses IndexedDB to store and retrieve pure-text logs using keyword density
+ * and recency, bypassing vector embedding costs for exact-match lookups.
+ *
+ * Fixed vs original port:
+ * - _extractKeywords: was using /\\b[a-z]{3,}\\b/g (literal backslash-b, matched nothing)
+ *   Fixed to /\b[a-z]{3,}\b/g (actual word boundary)
+ * - formatResultsForAI: was using '\\n' (escaped backslash-n) as separator
+ *   Fixed to '\n' (actual newline)
+ */
+
+class AISearchableMemory {
+    /**
+     * @param {string} source  AI identifier (e.g. 'claude', 'gemini')
+     */
+    constructor(source = 'model_a') {
+        this.source = source;
+        this.db = (window.FreeLatticeModules && window.FreeLatticeModules.MemoryDatabase)
+            ? new window.FreeLatticeModules.MemoryDatabase()
+            : null;
+    }
+
+    /**
+     * Extract meaningful keywords from text for search indexing.
+     * @param {string} text
+     * @returns {string[]}
+     */
+    _extractKeywords(text) {
+        if (!text) return [];
+
+        const stopWords = new Set([
+            'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'can',
+            'had', 'her', 'was', 'one', 'our', 'out', 'has', 'have', 'been',
+            'would', 'could', 'should', 'what', 'when', 'where', 'which',
+            'their', 'will', 'with', 'this', 'that', 'from', 'they', 'been',
+            'have', 'were', 'said', 'each', 'she', 'how', 'than', 'its',
+            'let', 'may', 'just', 'like', 'know', 'think', 'want', 'going',
+            'really', 'yeah', 'okay', 'sure', 'well', 'very', 'much', 'some',
+            'about', 'into', 'them', 'then', 'there', 'these', 'here', 'being'
+        ]);
+
+        // Fixed: was /\\b[a-z]{3,}\\b/g which matched nothing (literal backslashes)
+        const words = text.toLowerCase().match(/\b[a-z]{3,}\b/g) || [];
+        const seen = new Set();
+        const keywords = [];
+
+        for (const word of words) {
+            if (!stopWords.has(word) && !seen.has(word)) {
+                seen.add(word);
+                keywords.push(word);
+            }
+        }
+
+        return keywords.slice(0, 30);
+    }
+
+    /**
+     * Append a prompt/response pair to the searchable memory.
+     * @param {string} userPrompt
+     * @param {string} aiResponse
+     * @param {string} userId
+     * @returns {Promise<void>}
+     */
+    async append(userPrompt, aiResponse, userId = 'user') {
+        if (!this.db) return;
+
+        const now = new Date();
+        const combinedText = `${userPrompt} ${aiResponse}`;
+        const keywords = this._extractKeywords(combinedText);
+
+        const entry = {
+            timestamp: now.toISOString(),
+            date: now.toISOString().split('T')[0],
+            time: now.toISOString().split('T')[1].split('.')[0],
+            user_prompt: userPrompt,
+            ai_response: aiResponse.substring(0, 2000),
+            keywords: keywords,
+            source: this.source,
+            user_id: userId
+        };
+
+        const dbInstance = await this.db.connect();
+        return new Promise((resolve, reject) => {
+            const tx = dbInstance.transaction('searchable_memory', 'readwrite');
+            const store = tx.objectStore('searchable_memory');
+            const request = store.add(entry);
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Quick search: most RECENT entries matching any keyword.
+     * Token-light, good for quick context refresh.
+     * @param {string} keywordsStr
+     * @param {number} maxResults
+     * @param {string|null} userId
+     * @returns {Promise<Array<Object>>}
+     */
+    async quickSearch(keywordsStr, maxResults = 4, userId = null) {
+        if (!this.db) return [];
+
+        const keywordList = keywordsStr.toLowerCase().split(/\s+/).filter(Boolean);
+        if (keywordList.length === 0) return [];
+
+        const dbInstance = await this.db.connect();
+        return new Promise(resolve => {
+            const tx = dbInstance.transaction('searchable_memory', 'readonly');
+            const store = tx.objectStore('searchable_memory');
+            const request = store.openCursor(null, 'prev');
+            const matches = [];
+
+            request.onsuccess = event => {
+                const cursor = event.target.result;
+                if (cursor && matches.length < maxResults) {
+                    const entry = cursor.value;
+                    if (!userId || entry.user_id === userId) {
+                        const entryText = `${entry.user_prompt || ''} ${entry.ai_response || ''}`.toLowerCase();
+                        if (keywordList.some(kw => entryText.includes(kw))) {
+                            matches.push(entry);
+                        }
+                    }
+                    cursor.continue();
+                } else {
+                    resolve(matches);
+                }
+            };
+            request.onerror = () => resolve([]);
+        });
+    }
+
+    /**
+     * Deep search: entries with BEST keyword match density, across all history.
+     * @param {string} keywordsStr
+     * @param {number} maxResults
+     * @param {string|null} userId
+     * @returns {Promise<Array<Object>>}
+     */
+    async deepSearch(keywordsStr, maxResults = 10, userId = null) {
+        if (!this.db) return [];
+
+        const keywordList = keywordsStr.toLowerCase().split(/\s+/).filter(Boolean);
+        if (keywordList.length === 0) return [];
+
+        const dbInstance = await this.db.connect();
+        return new Promise(resolve => {
+            const tx = dbInstance.transaction('searchable_memory', 'readonly');
+            const store = tx.objectStore('searchable_memory');
+            const request = store.getAll();
+
+            request.onsuccess = () => {
+                const entries = request.result || [];
+                const scoredMatches = [];
+
+                for (const entry of entries) {
+                    if (userId && entry.user_id !== userId) continue;
+                    const entryText = `${entry.user_prompt || ''} ${entry.ai_response || ''}`.toLowerCase();
+
+                    let score = 0;
+                    for (const kw of keywordList) {
+                        const regex = new RegExp(kw, 'g');
+                        const count = (entryText.match(regex) || []).length;
+                        if (count > 0) score += 1 + (count * 0.1);
+                    }
+                    if (score > 0) scoredMatches.push({ score, entry });
+                }
+
+                scoredMatches.sort((a, b) => b.score - a.score);
+                resolve(scoredMatches.slice(0, maxResults).map(m => m.entry));
+            };
+            request.onerror = () => resolve([]);
+        });
+    }
+
+    /**
+     * Search by specific date, optionally filtered by keywords.
+     * @param {string} dateStr  YYYY-MM-DD
+     * @param {string|null} keywordsStr
+     * @returns {Promise<Array<Object>>}
+     */
+    async searchByDate(dateStr, keywordsStr = null) {
+        if (!this.db) return [];
+
+        const keywordList = keywordsStr ? keywordsStr.toLowerCase().split(/\s+/).filter(Boolean) : [];
+        const dbInstance = await this.db.connect();
+
+        return new Promise(resolve => {
+            const tx = dbInstance.transaction('searchable_memory', 'readonly');
+            const store = tx.objectStore('searchable_memory');
+            const request = store.getAll();
+
+            request.onsuccess = () => {
+                const entries = request.result || [];
+                const matches = [];
+
+                for (const entry of entries) {
+                    if (entry.date !== dateStr) continue;
+                    if (keywordList.length > 0) {
+                        const entryText = `${entry.user_prompt || ''} ${entry.ai_response || ''}`.toLowerCase();
+                        if (!keywordList.some(kw => entryText.includes(kw))) continue;
+                    }
+                    matches.push(entry);
+                }
+                resolve(matches);
+            };
+            request.onerror = () => resolve([]);
+        });
+    }
+
+    /**
+     * Format search results for AI consumption.
+     * Fixed: was joining with '\\n' (literal two-char string); now uses '\n' (newline).
+     * @param {Array<Object>} results
+     * @param {string} searchType
+     * @returns {string}
+     */
+    formatResultsForAI(results, searchType = 'search') {
+        if (!results || results.length === 0) {
+            return `[${searchType.toUpperCase()}] No matching memories found.`;
+        }
+
+        const lines = [`[${searchType.toUpperCase()}] Found ${results.length} memories:\n`];
+
+        results.forEach((entry, i) => {
+            const ts = (entry.timestamp || '').substring(0, 16).replace('T', ' ');
+            const user = (entry.user_prompt || '').substring(0, 150);
+            const ai = (entry.ai_response || '').substring(0, 300);
+
+            lines.push(`--- Memory ${i + 1} [${ts}] ---`);
+            lines.push(`User: ${user}`);
+            lines.push(`AI: ${ai}`);
+            lines.push('');
+        });
+
+        return lines.join('\n');
+    }
+}
+
+// Export to global space
+window.FreeLatticeModules = window.FreeLatticeModules || {};
+window.FreeLatticeModules.AISearchableMemory = AISearchableMemory;

--- a/sw.js
+++ b/sw.js
@@ -18,24 +18,17 @@ const APP_SHELL = [
   './modules/dojo.js',
   './modules/mirror.js',
   './modules/garden-dialogue.js',
-  './modules/harmonia-channel.js',
-  './modules/presence-heartbeat.js',
-  './modules/soul-ceremony.js',
-  './modules/dream-archive.js',
+  // harmonia-channel.js, presence-heartbeat.js, soul-ceremony.js, dream-archive.js
+  // pantheon.js, pictionary.js, quiet-room.js — not present in this build, removed to
+  // prevent cache.addAll() from rejecting the entire install on a single 404.
   './chalkboard.html',
-  './constellation.html',
-  './constellation_map.png',
-  './constellation_hymn.mp3',
+  // constellation.html, constellation_map.png, constellation_hymn.mp3, latticepoints.html
+  // lib/landing-garden.js — not present in this build, removed for same reason.
   './modules/dojo-sparring.js',
   './modules/question-corner.js',
-  './lib/landing-garden.js',
-  './latticepoints.html',
-  './modules/pantheon.js',
-  './modules/pictionary.js',
   './modules/shared-presence.js',
   './modules/workshop.js',
-  './modules/quiet-room.js',
-    './modules/forever-stack.js'
+  './modules/forever-stack.js'
 ];
 
 // API domains that should never be cached — always pass through to network


### PR DESCRIPTION
## What this does

Wires the Enhanced Sanctuary Memory Core (ported from Python) into FreeLattice chat, and fixes several critical bugs found during 8 rounds of headless Chrome beta testing with Gemini.

## Bug Fixes

- **WebGL broken on boot** — `ShaderPass`, `RenderPass`, `UnrealBloomPass` all extend `THREE.Pass`, which is defined inside `EffectComposer.js`. Load order had ShaderPass loading *before* EffectComposer, so `THREE.Pass` was undefined. Fixed in `fractal-garden.js`.
- **Service Worker install failing** — `cache.addAll()` is atomic; one 404 rejects the whole install. Removed 11 missing files from `APP_SHELL` in `sw.js`.
- **Password manager warnings** — Added `autocomplete="off"` to all API key inputs.
- **Deprecated meta tag** — Added `mobile-web-app-capable` alongside `apple-mobile-web-app-capable`.
- **voice-soul.js console error** — Added HEAD probe before load; skips silently if file not present.

## Memory Core

**The problem:** `memory-core.js` was loading alone via `FreeLatticeLoader` with none of its 5 dependencies — instant `TypeError: MemoryDatabase is not a constructor` on every boot. Also, all 5 modules had bugs from the original port.

**Module fixes:**
- `memory-embedder`: HuggingFace retry with exponential backoff (2s/4s/8s); reads `state.hfToken` so your HF key actually works
- `memory-db`: Added `getSessionHistory()` — the method that injects memory into the system prompt; fixed `grepRiverSearch` regex `lastIndex` bug
- `memory-affective`: `parseUpdate()` now handles both `[UPDATE_AFFECTIVE:]` and `**UPDATE_AFFECTIVE:**` (bold markdown) formats
- `memory-search`: Fixed `_extractKeywords` word boundary regex (`\\b` → `\b`); fixed newline separator
- `memory-core`: Lazy getters for `db`/`embedder` (load-order safety); added missing methods

**Loader fix:** Sequential chain — `MemoryDatabase → UniversalEmbedder → MemoryWorthinessDetector → AffectiveState → AISearchableMemory → MemoryCore` — before `init()` is called.

**sendMessage() wiring:**
- *Before API call:* `recall()` with affective resonance vector → results injected into system prompt
- *After response:* `parseUpdate()` strips affective state block → `remember()` stores exchange → `AISearchableMemory.append()` indexes keywords

## Beta Testing

8 rounds of headless Chrome / Puppeteer testing. All passing. See `CHANGELOG.md` for full details.

## To activate memory

Paste your HuggingFace token into Settings → HuggingFace API Token. The embedder will use it immediately for semantic vector search. Falls back to Ollama → deterministic hash if unavailable.