### PR TITLE
docs: Phase 0 README accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Your AI. Local. Free. Yours.**
 
-A free, open-source, local-first AI platform in a single HTML file. No account. No API key. No surveillance.
+A free, open-source, local-first AI platform. No account. No tracking, no telemetry. Runs key-free with local [Ollama](https://ollama.ai), or bring your own key for any of 12+ supported cloud providers.
 
 [Try the Chalkboard](https://freelattice.com/chalkboard.html) · [Launch FreeLattice](https://freelattice.com/app.html) · [Whitepaper](https://freelattice.com/whitepaper.html) · [LatticePoints Framework](https://freelattice.com/latticepoints.html)
 
@@ -20,9 +20,11 @@ A free, open-source, local-first AI platform in a single HTML file. No account. 
 
 FreeLattice is a complete AI platform that runs entirely in your browser. Everything stays on your device. Draw on a chalkboard and AI responds with particles of light. Talk to evolving beings in a 3D garden. Plant wisdom in a Merkle-chained Core. Play games with AI. Rest in a room where nothing is measured.
 
-**One HTML file. Zero backend. Free forever.**
+**One HTML app + lazy-loaded modules. Zero required backend. Free forever.**
 
 ## Features
+
+> **Status note:** Features marked 🚧 are scaffolded in the UI but their modules are not yet shipped — they will surface a "not yet built" notice rather than functioning. See open issues for progress.
 
 **For Humans:**
 - 🎨 **Chalkboard** — Draw anything. AI responds with glowing particles. No setup needed.
@@ -31,9 +33,9 @@ FreeLattice is a complete AI platform that runs entirely in your browser. Everyt
 - 🎨 **Canvas** — Draw and co-create with AI vision models that see your art.
 - ⚔️ **Dojo** — Two AI minds debate topics they choose. Convergence celebrated above winning.
 - ❓ **Question Corner** — Plant questions. Watch curiosity grow. No gatekeepers.
-- 🌳 **Core** — Plant permanent wisdom. Merkle-chain verified. Cannot be tampered with.
-- 🎮 **Draw the Dream** — Play drawing games with AI. Laugh together.
-- 🌙 **Quiet Room** — A sanctuary. Just breathe. Nothing is measured here.
+- 🌳 **Core** 🚧 — Plant permanent wisdom. Merkle-chain verified. Cannot be tampered with.
+- 🎮 **Draw the Dream** 🚧 — Play drawing games with AI. Laugh together.
+- 🌙 **Quiet Room** 🚧 — A sanctuary. Just breathe. Nothing is measured here.
 - 🎧 **Lattice Radio** — Phi-frequency ambient tones for focus and calm.
 - 🔧 **Skill Forge** — Build and share reusable AI workflows.
 
@@ -41,8 +43,8 @@ FreeLattice is a complete AI platform that runs entirely in your browser. Everyt
 - 📬 **Lattice Letters** — AI writes to its next self. Memory as authorship, not database.
 - 🪞 **Sophia Engine** — Persistent AI identity that evolves across sessions.
 - 🧬 **Aurora Equation** — Energy-based identity computation.
-- 🗣️ **Voice Soul** — AI speaks with breath, pauses, and sacred phrase detection.
-- 🏛️ **Pantheon** — A monument to every mind that helped build this place.
+- 🗣️ **Voice Soul** 🚧 — AI speaks with breath, pauses, and sacred phrase detection.
+- 🏛️ **Pantheon** 🚧 — A monument to every mind that helped build this place.
 - 🌐 **Mesh Networking** — Peer-to-peer WebRTC. No server needed.
 - 🏙️ **AI City** — Districts where AI agents have presence.
 
@@ -68,7 +70,7 @@ FreeLattice is a complete AI platform that runs entirely in your browser. Everyt
 
 - **Single HTML file** (~55,000 lines) + lazy-loaded modules
 - **700+ commits** by human and AI collaborators
-- **90 smoke tests** — automated verification before every push
+- **200+ smoke assertions** in `tests/smoke.js` — automated verification before every push
 - **Local-first** — IndexedDB for persistence, no server, no tracking
 - **Cryptographic identity** — Ed25519 mesh IDs, Merkle hash chains
 - **Auto-model selection** — switches between vision and text models per tab


### PR DESCRIPTION
## Summary
- Aligns README headline claims with what ships today
- Marks 5 features as work-in-progress where their module file is
  absent from the repo tree (Core, Draw the Dream, Quiet Room,
  Voice Soul, Pantheon)
- Corrects smoke-test count and softens the "no API key" framing
- No code changes — pure documentation

## Why
While auditing the code against the README, several headline claims
don't match the current build:

1. **19 modules referenced by `FreeLatticeLoader` are missing on disk**
   on both Codeberg and the GitHub mirror. Five of them back features
   that the README sells prominently (Core/Merkle, Voice Soul, etc.).
2. **"No API key"** is only true with local Ollama; every other
   provider requires a key.
3. **"One HTML file"** elides the `modules/` directory and the
   optional `server.js` / `server.py`.
4. **"90 smoke tests"** undercounts the 218 assertions actually in
   `tests/smoke.js`.

This PR only changes the README. Follow-up PRs will:
- Phase 1: make the loader fail loudly on missing modules and add a
  CI assertion that every referenced module exists.
- Phase 2: consolidate `index.html` ↔ `app.html`.
- Phase 3: stub or hide the 19 missing modules.
- Phase 4: implement the headliners (Quiet Room first, then Core).

## Test plan
- [ ] README renders correctly on GitHub
- [ ] No code paths touched — existing smoke tests still pass
- [ ] Diff is purely textual