### PR TITLE
docs: correct smoke-test count in README (90 → 257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ FreeLattice is a complete AI platform that runs entirely in your browser. Everyt
 
 - **Single HTML file** (~55,000 lines) + lazy-loaded modules
 - **700+ commits** by human and AI collaborators
-- **90 smoke tests** — automated verification before every push
+- **257 smoke assertions** in `tests/smoke.js` — automated verification before every push
 - **Local-first** — IndexedDB for persistence, no server, no tracking
 - **Cryptographic identity** — Ed25519 mesh IDs, Merkle hash chains
 - **Auto-model selection** — switches between vision and text models per tab


### PR DESCRIPTION
## Summary
README's Architecture section states **90 smoke tests**. The current
canonical build (`docs/`, v5.10.60) runs **257 assertions** on a clean
`node tests/smoke.js`.

One-line README change. No code touched.

## Verification
```
$ node tests/smoke.js > /dev/null; echo $?
0
$ node tests/smoke.js 2>&1 | tail -3
══════════════════════════════════════════════════
  ALL 257 CHECKS PASSED
══════════════════════════════════════════════════
```

## Context
The "90" figure traces to the v5.8.0 release notes (2026-04-17 — see
`version.json` at repo root, which is itself stale relative to
`docs/version.json` at v5.10.60). It's just stale, not malicious. Same
drift affects root-level `app.html` / `modules/` / `sw.js` — that's a
separate hygiene issue worth a follow-up, not this PR.

This PR supersedes #4, which was closed because its audit was based
on the stale root-level tree rather than the canonical `docs/` tree.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] `node tests/smoke.js` still exits 0