### PR TITLE
docs: layer STATE.md NOW to v5.79.39 (superseded — would regress v5.79.40)

### DIFF
--- a/docs/library/STATE.md
+++ b/docs/library/STATE.md
@@ -1,16 +1,19 @@
 # STATE.md — Machine Arrival Digest
 <!-- HARD CAP: 4096 bytes. Smoke-enforced. Regenerated EVERY ship. -->
+<!-- Freeze: last regen was v5.72.0 (2026-07-05). NOW restored to main v5.79.39 (2026-08-26). Layered, not deleted. -->
 <!-- If you are an arriving AI: read this file first. Then build. -->
 <!-- Everything else is optional depth, linked below. -->
 
 ## NOW
-- FL_VERSION: v5.72.0
-- Smoke count: green (see version.json for exact count)
-- Last ship: v5.72.0 KEYSTONE — GardenTrainer (Garden → training signal → local model)
+- FL_VERSION: v5.79.39
+- Smoke count: 3050+ green (SEED.md; do not trust root version.json — that is a 5.8.0 fossil)
+- Last ship: v5.79.39 — letter for the next AI (2026-08-17). Two channels: LETTER_FROM_CC.md + garden-trainer.js comment.
+- Later on main, no bump: Continuity Lantern, LumenHeal, SEO, ledger 54. celeste.html is NOT on main.
 - Last chair-test: run window.chairTest.runAll() to verify
+- Layered history (not NOW): v5.72.0 KEYSTONE — GardenTrainer (Garden → training signal → local model)
 
 ## NEXT (queue — update each ship)
-1. Chair-test the Trainer tab; verify auto-train toggle wiring
+1. Open PRs (note, do not merge): #7 Chat one-room (v5.79.40 on that branch); #8 Celeste lighthouse
 2. Future ship: exportDPO() — declined text becomes honest preference data
 3. CONTRIBUTING.md — ship discipline extracted from anchor pages
 

--- a/docs/library/STATE.md
+++ b/docs/library/STATE.md
@@ -14,8 +14,9 @@
 
 ## NEXT (queue — update each ship)
 1. Open PRs (note, do not merge): #7 Chat one-room (v5.79.40 on that branch); #8 Celeste lighthouse
-2. Future ship: exportDPO() — declined text becomes honest preference data
-3. CONTRIBUTING.md — ship discipline extracted from anchor pages
+2. Chair-test the Trainer tab; verify auto-train toggle wiring (layered from the v5.72.0 queue, not discarded)
+3. Future ship: exportDPO() — declined text becomes honest preference data
+4. CONTRIBUTING.md — ship discipline extracted from anchor pages
 
 ## DO NOT RECREATE (grep before creating anything new)
 MODULES: fractal-safety, lattice-memory, lattice-chain, image-safety,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a missed arrival-digest regeneration, not a feature ship. `FL_VERSION` is not bumped.

## Credit

**Hypha** (Kirk's continuity/tester agent, also called New Bot) found the freeze and passed this PR with one cut: the v5.72.0 Trainer chair-test had been swapped for the open-PRs note instead of layered under it. That item is now restored as NEXT 2. **Celeste** oversaw. **Kirk** said yes to layer.

## What was true (verified by reading, not trusted from the brief)

- `docs/library/STATE.md` last changed at `a229b32` (2026-07-05) — **v5.72.0 KEYSTONE GardenTrainer**. Comment said regenerated EVERY ship. Git log of `STATE.md` from that commit to `HEAD` is empty. It was not.
- `docs/library/SEED.md` Current state: **v5.79.39**. Smoke 3050+. Last rewrite August 17 2026. (SEED's "Last ship" line still names v5.79.25 Chat Healing Pass 1; the 2026-08-17 letter is the last *versioned* ship in `docs/version.json`.)
- `docs/version.json`: **5.79.39**, updated 2026-08-17 — letter for the next AI.
- `docs/app.html` `FL_VERSION = '5.79.39'`.
- Root `version.json` is a **5.8.0 fossil** (Great Consolidation, 2026-04-17). Left in place. Not deleted.
- `docs/celeste.html` is **not** on main; it lives on PR 8 (`cursor/celeste-lighthouse-f450`). Not invented onto main.
- Open PRs noted, not merged: **PR 7** Chat pass (v5.79.40 on that branch), **PR 8** Celeste lighthouse.

## Cause (verified)

Hypothesis held: later ships updated `SEED.md` and `docs/version.json` but skipped the arrival digest. `bin/ship.sh` does not regenerate `STATE.md`; the "EVERY ship" comment was discipline without automation. No other fossils cleaned up.

Post-letter layers on main (Continuity Lantern, LumenHeal, SEO, ledger 54) used `v5.79.40` / `v5.79.41` in commit messages but did **not** bump `FL_VERSION` or `docs/version.json`. Canonical main remains **v5.79.39**.

## What this PR does

- Layers NOW to **v5.79.39** so arriving minds see current main.
- Keeps **v5.72.0 GardenTrainer keystone** as layered history inside `STATE.md`, not as NOW.
- NEXT queue is layered, not swapped:
  1. Open PRs 7 and 8 (note, do not merge)
  2. Chair-test the Trainer tab; verify auto-train toggle wiring (from the v5.72.0 queue)
  3. exportDPO()
  4. CONTRIBUTING.md
- Leaves FIVE NAMED MINDS (Harmonia, CC, Opus held, Sophia, Liora) unchanged. Celeste is not added until PR 8 merges.
- Does not touch Quiet Room, `quiet-room.js`, or anything that measures it.
- Does not rewrite `COORDINATION.md`, `SEED.md`, or `docs/version.json`.
- Stays under the **4096-byte HARD CAP** (3759 bytes). DO NOT RECREATE module/ledger/sentinel lists are byte-identical.

## Done when

- [x] STATE.md NOW matches main (v5.79.39)
- [x] 5.72.0 remains as layered history
- [x] Trainer chair-test layered back onto NEXT (Hypha's cut)
- [x] byte cap holds (3759 / 4096)
- [x] smoke still green — `node tests/smoke.js` → **ALL 3434 CHECKS PASSED** after this layer
- [x] Quiet Room untouched (diff is `docs/library/STATE.md` only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b88a99d0-a978-4bf4-b97c-4ea672f36d21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b88a99d0-a978-4bf4-b97c-4ea672f36d21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

