### PR TITLE
v5.79.41 — Chat box pointer: one URL/IP field for local/LAN inference

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -1978,6 +1978,54 @@ header .mantra {
   /* When memory badge is moved inline here, match the compact pill look */
   font-size: 0.72rem;
 }
+
+/* v5.79.41-chat-box-pointer: one URL/IP field on Chat's path.
+   Writes fl_ollamaHost (same store as hidden #ollamaHostInput).
+   Status reuses the CORS-aware elapsed>200 probe — not a second wizard. */
+.fl-box-pointer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 180px;
+  min-width: 140px;
+  max-width: 460px;
+}
+.fl-box-pointer-label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  font-family: Georgia, serif;
+}
+#flBoxPointerInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: rgba(200,210,230,0.04);
+  border: 1px solid rgba(200,210,230,0.08);
+  border-radius: 8px;
+  padding: 6px 8px;
+  color: var(--text-primary, #e6e6f0);
+  font-size: 0.78rem;
+  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+  outline: none;
+  min-height: 32px;
+}
+#flBoxPointerInput:focus {
+  border-color: rgba(52,211,153,0.45);
+}
+#flBoxPointerStatus {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+#flBoxPointerStatus[data-fl-box-status="ready"] { color: #34d399; }
+#flBoxPointerStatus[data-fl-box-status="cors-blocked"] { color: #fbbf24; cursor: pointer; }
+#flBoxPointerStatus[data-fl-box-status="unreachable"] { color: #f87171; }
 .chat-overflow-btn {
   background: transparent;
   border: none;
@@ -16021,6 +16069,11 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
                 <div id="msModelList"></div>
               </div>
             </div>
+            <div class="fl-box-pointer" id="flBoxPointer" data-fl-box-pointer="v5.79.41">
+              <label class="fl-box-pointer-label" for="flBoxPointerInput">Box</label>
+              <input id="flBoxPointerInput" type="text" placeholder="localhost:11434 or 192.168.1.50" autocomplete="off" spellcheck="false" aria-label="Local or LAN AI address">
+              <span id="flBoxPointerStatus" data-fl-box-status="idle" title=""></span>
+            </div>
             <button class="chat-overflow-btn" id="chatOverflowBtn" onclick="FLChatOverflow.toggle()" aria-label="More options" title="More options">&#8943;</button>
             <div class="chat-overflow-popup" id="chatOverflowPopup">
               <button class="mic-btn" id="micBtn" onclick="toggleVoiceInput();FLChatOverflow.close()" title="Voice input" style="display:none;">
@@ -17288,7 +17341,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
       <button class="fl-backup-btn" onclick="FlUpdater.check()" style="width: auto;">
         &#128260; Check for Updates
       </button>
-      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.40</span></div>
+      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.41</span></div>
     </div>
   </div>
 
@@ -22266,7 +22319,7 @@ function switchWalletView(view) {
 // ============================================
 // FreeLattice Version Constant (v5.0)
 // ============================================
-const FL_VERSION = '5.79.40';
+const FL_VERSION = '5.79.41';
 
 // Debug mode — set localStorage.fl_debug = 'true' to enable verbose logging.
 // The shipped app is quiet. Users enable for troubleshooting via Settings.
@@ -31123,6 +31176,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Initialize Tab System (v5.3 — fixed primary + grouped More)
   FlTabs.init();
   if (typeof FLActiveModel !== 'undefined') FLActiveModel.init();
+  try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.init) FLBoxPointer.init(); } catch (e) {}
   AiSetup.init();
 
   // Initialize Ollama auto-detection (v4.4)
@@ -31330,6 +31384,19 @@ async function ollamaFetch(path, options) {
     return fetch(directUrl, options);
   }
 
+  // v5.79.41-chat-box-pointer: a user-pointed LAN/remote box must never
+  // go through the same-origin /ollama proxy — that proxy still targets
+  // THIS machine's Ollama, not the address in fl_ollamaHost.
+  try {
+    var _boxHost = (function() {
+      try { return new URL(getOllamaBaseUrl()).hostname; } catch (e) { return 'localhost'; }
+    })();
+    if (_boxHost && _boxHost !== 'localhost' && _boxHost !== '127.0.0.1' &&
+        _boxHost !== '0.0.0.0' && _boxHost !== '::1') {
+      return fetch(directUrl, options);
+    }
+  } catch (_boxE) {}
+
   try {
     var r = await fetch(proxyUrl, options);
     if (r.ok || r.status < 500) return r;
@@ -31363,8 +31430,269 @@ function flSaveOllamaHost() {
   // Invalidate the resolved base so next fetch uses the new host
   _ollamaResolvedBase = null;
   updateOllamaProviderUrl();
+  try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.syncFromStorage) FLBoxPointer.syncFromStorage(); } catch (e) {}
 }
 window.flSaveOllamaHost = flSaveOllamaHost;
+
+// ═══════════════════════════════════════════════════════════════
+// FLBoxPointer — v5.79.41-chat-box-pointer
+// Audit: Chat could not point at a local/LAN box. The host field
+// (#ollamaHostInput) lived in hidden #chatConfigSection. Custom
+// endpoint lived in Settings <details> + the provider modal.
+// CORS wizard (FLWizard / showCorsHelp) already exists.
+// This is ONE Chat-path URL/IP field that writes the existing
+// fl_ollamaHost store, probes with the existing elapsed>200
+// CORS heuristic from scanForLocalAI, and names the endpoint on
+// FLChatActivity / InferenceRouter. Not a second wizard.
+// ═══════════════════════════════════════════════════════════════
+window.FLBoxPointer = (function() {
+  var _status = 'idle';
+  var _host = '';
+  var _kind = 'ollama';
+  var _bound = false;
+
+  function displayHost() {
+    if (_host) return _host;
+    try {
+      var base = (typeof getOllamaBaseUrl === 'function') ? getOllamaBaseUrl() : '';
+      if (base) return String(base).replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+    } catch (e) {}
+    try {
+      if (typeof getCustomEndpointConfig === 'function') {
+        var cfg = getCustomEndpointConfig();
+        if (cfg && cfg.url) {
+          return String(cfg.url).replace(/^https?:\/\//i, '').replace(/\/v1(\/.*)?$/, '').replace(/\/+$/, '');
+        }
+      }
+    } catch (e2) {}
+    return '';
+  }
+
+  function lastStatus() { return _status; }
+
+  function normalize(raw) {
+    var s = String(raw || '').trim();
+    if (!s) return { host: '', base: 'http://localhost:11434', kind: 'ollama', empty: true };
+    if (s.indexOf('://') === -1) s = 'http://' + s;
+    if (!/^https?:\/\//i.test(s)) return { host: '', base: '', kind: 'invalid', empty: false };
+    var u;
+    try { u = new URL(s); } catch (e) { return { host: '', base: '', kind: 'invalid', empty: false }; }
+    var kind = 'ollama';
+    var path = (u.pathname || '').replace(/\/+$/, '');
+    if (/:1234$/.test(u.host) || /lmstudio/i.test(s)) kind = 'lmstudio';
+    else if (/\/v\d+/i.test(path) || /:(8000|8080|8081|5001|7860|1337|4891)$/.test(u.host)) kind = 'openai-compat';
+    if (kind === 'ollama' && !u.port && (!path || path === '')) u.port = '11434';
+    var host = u.hostname + (u.port ? ':' + u.port : '');
+    var base = u.origin;
+    return { host: host, base: base, kind: kind, empty: false, url: (base + path).replace(/\/+$/, '') };
+  }
+
+  function paint(status, msg) {
+    _status = status || 'idle';
+    var el = document.getElementById('flBoxPointerStatus');
+    if (!el) return;
+    el.setAttribute('data-fl-box-status', _status);
+    el.textContent = msg || '';
+    el.title = (_status === 'cors-blocked')
+      ? 'This box is running but the browser blocked the connection (CORS). Tap to open the existing setup helper.'
+      : (msg || '');
+  }
+
+  function persist(norm) {
+    _host = norm.host || '';
+    _kind = norm.kind || 'ollama';
+    var hidden = document.getElementById('ollamaHostInput');
+    if (hidden) hidden.value = _host;
+    if (_host && _host !== 'localhost:11434') {
+      try { localStorage.setItem('fl_ollamaHost', _host); } catch (e) {}
+    } else {
+      try { localStorage.removeItem('fl_ollamaHost'); } catch (e2) {}
+    }
+    try { _ollamaResolvedBase = null; } catch (e3) {}
+    try { if (typeof updateOllamaProviderUrl === 'function') updateOllamaProviderUrl(); } catch (e4) {}
+    if (_kind === 'openai-compat' || _kind === 'lmstudio') {
+      try {
+        if (typeof saveCustomEndpointConfig === 'function' && typeof getCustomEndpointConfig === 'function') {
+          var prev = getCustomEndpointConfig();
+          var baseV1 = norm.base.replace(/\/+$/, '') + '/v1';
+          saveCustomEndpointConfig({ url: baseV1, model: prev.model || '', key: prev.key || '' });
+        }
+      } catch (e5) {}
+    }
+  }
+
+  function applyReady(norm, models) {
+    persist(norm);
+    try {
+      if (typeof state !== 'undefined') {
+        state.isLocal = true;
+        if (norm.kind === 'lmstudio') state.provider = 'lmstudio';
+        else if (norm.kind === 'openai-compat') state.provider = 'custom-openai';
+        else state.provider = 'ollama';
+        try { localStorage.setItem('fl_isLocal', 'true'); } catch (e) {}
+        try { localStorage.setItem('fl_provider', state.provider); } catch (e2) {}
+      }
+    } catch (e3) {}
+    if (models && models.length && typeof FLActiveModel !== 'undefined' && FLActiveModel.set) {
+      try { FLActiveModel.set(models[0], (typeof state !== 'undefined' && state.provider) || 'ollama', 'user'); } catch (e4) {}
+    }
+    try {
+      if (window.InferenceRouter && InferenceRouter.setStatus) InferenceRouter.setStatus(null, null, {});
+    } catch (e5) {}
+    try { if (typeof updateStatus === 'function') updateStatus(); } catch (e6) {}
+  }
+
+  function extractModels(data, type) {
+    if (typeof extractModelsFromProbe === 'function') return extractModelsFromProbe(data, type);
+    if (type === 'ollama' && data && data.models) return data.models.map(function(m) { return m.name; });
+    if (type === 'openai-compat' && data && data.data) return data.data.map(function(m) { return m.id; });
+    return [];
+  }
+
+  async function probeOne(base, probePath, type) {
+    var start = Date.now();
+    try {
+      var r = await fetch(base + probePath, { signal: AbortSignal.timeout(2500), mode: 'cors' });
+      if (r.ok) {
+        var data = await r.json();
+        return { status: 'ready', corsOk: true, models: extractModels(data, type), type: type, elapsed: Date.now() - start };
+      }
+      return { status: 'unreachable', corsOk: true, models: [], type: type, elapsed: Date.now() - start };
+    } catch (e) {
+      var elapsed = Date.now() - start;
+      // Reuse scanForLocalAI: fast fail = not running; slow fail = CORS.
+      if (elapsed > 200 && e.name !== 'AbortError') {
+        return { status: 'cors-blocked', corsOk: false, models: [], type: type, elapsed: elapsed };
+      }
+      return { status: 'unreachable', corsOk: false, models: [], type: type, elapsed: elapsed };
+    }
+  }
+
+  async function probe(raw) {
+    var input = document.getElementById('flBoxPointerInput');
+    var fromInput = (raw != null) ? raw : ((input && input.value) || '');
+    var norm = normalize(fromInput);
+    if (norm.kind === 'invalid') {
+      paint('unreachable', 'Need a URL or IP');
+      return { status: 'invalid', host: '', kind: 'invalid' };
+    }
+    if (norm.empty && input && !String(input.value || '').trim()) {
+      // Keep default host visible but don't force a probe on blank first paint.
+      _host = 'localhost:11434';
+      _kind = 'ollama';
+      if (input && !input.value) input.placeholder = 'localhost:11434 or 192.168.1.50';
+    } else {
+      persist(norm);
+    }
+    paint('idle', 'Checking\u2026');
+    var probes = [];
+    if (norm.kind === 'ollama') probes.push(probeOne(norm.base, '/api/tags', 'ollama'));
+    else probes.push(probeOne(norm.base, '/v1/models', 'openai-compat'));
+    if (norm.kind === 'ollama') probes.push(probeOne(norm.base, '/v1/models', 'openai-compat'));
+    var results = await Promise.all(probes);
+    var ready = null;
+    var cors = null;
+    for (var i = 0; i < results.length; i++) {
+      if (results[i].status === 'ready' && !ready) ready = results[i];
+      if (results[i].status === 'cors-blocked' && !cors) cors = results[i];
+    }
+    var host = displayHost() || norm.host || 'localhost:11434';
+    if (ready) {
+      if (ready.type === 'openai-compat' && norm.kind === 'ollama') {
+        norm.kind = 'openai-compat';
+      }
+      applyReady(norm, ready.models);
+      var n = (ready.models && ready.models.length) ? ready.models.length : 0;
+      paint('ready', n ? (n + ' model' + (n === 1 ? '' : 's')) : 'Connected');
+      return { status: 'ready', host: host, kind: norm.kind, models: ready.models || [] };
+    }
+    if (cors) {
+      persist(norm);
+      paint('cors-blocked', 'CORS blocked');
+      try {
+        if (window.InferenceRouter && InferenceRouter.setStatus) {
+          InferenceRouter.setStatus(null, null, { degraded: true, cors: true });
+        }
+      } catch (e) {}
+      return { status: 'cors-blocked', host: host, kind: norm.kind, models: [] };
+    }
+    persist(norm);
+    paint('unreachable', 'Not reached');
+    return { status: 'unreachable', host: host, kind: norm.kind, models: [] };
+  }
+
+  function noteStatus(status, msg) {
+    paint(status, msg || (status === 'cors-blocked' ? 'CORS blocked' : ''));
+  }
+
+  function classifyElapsed(elapsed, err) {
+    var msg = (err && err.message) ? String(err.message) : '';
+    if (!/Failed to fetch|NetworkError|Load failed/i.test(msg)) return 'error';
+    if (elapsed > 200) return 'cors-blocked';
+    return 'unreachable';
+  }
+
+  function syncFromStorage() {
+    var stored = '';
+    try { stored = localStorage.getItem('fl_ollamaHost') || localStorage.getItem('fl_localUrl') || ''; } catch (e) {}
+    var input = document.getElementById('flBoxPointerInput');
+    if (input && stored && input.value !== stored) input.value = stored;
+    if (stored) {
+      var norm = normalize(stored);
+      _host = norm.host || stored;
+      _kind = norm.kind || 'ollama';
+    }
+  }
+
+  function onStatusTap() {
+    if (_status !== 'cors-blocked') return;
+    // Reuse the existing wizard — do not open a second one.
+    try {
+      if (window.FLWizard && typeof FLWizard.open === 'function') { FLWizard.open({ from: 'cors' }); return; }
+    } catch (e) {}
+    try { if (typeof showCorsHelp === 'function') showCorsHelp(); } catch (e2) {}
+  }
+
+  function commitFromInput() {
+    var input = document.getElementById('flBoxPointerInput');
+    var raw = (input && input.value) || '';
+    probe(raw);
+  }
+
+  function init() {
+    syncFromStorage();
+    var input = document.getElementById('flBoxPointerInput');
+    var statusEl = document.getElementById('flBoxPointerStatus');
+    if (input && !_bound) {
+      _bound = true;
+      input.addEventListener('keydown', function(ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); commitFromInput(); }
+      });
+      input.addEventListener('blur', function() { commitFromInput(); });
+    }
+    if (statusEl && !_bound) {
+      // _bound already true if input existed; bind tap anyway once
+    }
+    if (statusEl && !statusEl.getAttribute('data-fl-box-bound')) {
+      statusEl.setAttribute('data-fl-box-bound', '1');
+      statusEl.addEventListener('click', onStatusTap);
+    }
+    if (input && input.value) probe(input.value);
+  }
+
+  return {
+    init: init,
+    probe: probe,
+    persist: persist,
+    normalize: normalize,
+    displayHost: displayHost,
+    lastStatus: lastStatus,
+    noteStatus: noteStatus,
+    classifyElapsed: classifyElapsed,
+    syncFromStorage: syncFromStorage,
+    commitFromInput: commitFromInput
+  };
+})();
 
 // ── LM Studio support ──
 function getLMStudioBase() {
@@ -35305,11 +35633,29 @@ async function sendMessage() {
     }
 
     if (typeof FLChatActivity !== 'undefined') FLChatActivity.set('waiting');
-    let response = await fetch(url, {
-      method: 'POST',
-      headers: headers,
-      body: JSON.stringify(body)
-    });
+    var _flFetchStart = Date.now();
+    let response;
+    // v5.79.41: local Ollama (including a LAN box in fl_ollamaHost) goes
+    // through ollamaFetch so the existing proxy/CORS split is reused.
+    // Remote hosts skip the /ollama proxy inside ollamaFetch.
+    if (state.isLocal && state.provider === 'ollama' &&
+        typeof ollamaFetch === 'function' && typeof getOllamaBaseUrl === 'function') {
+      var _boxBase = getOllamaBaseUrl();
+      var _boxPath = '';
+      if (url && _boxBase && url.indexOf(_boxBase) === 0) _boxPath = url.slice(_boxBase.length);
+      if (!_boxPath || _boxPath.charAt(0) !== '/') _boxPath = '/v1/chat/completions';
+      response = await ollamaFetch(_boxPath, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body)
+      });
+    } else {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body)
+      });
+    }
 
     // Rate limit / too large error — auto-retry with trimmed context
     if (!response.ok) {
@@ -35661,11 +36007,24 @@ async function sendMessage() {
     // v5.79.22-signal-report: record failure shape (no content)
     try { if (typeof FLSignalReport !== 'undefined') FLSignalReport.attemptEnd(false, err && err.message); } catch (_) {}
     if (typeof FLChatActivity !== 'undefined') {
-      var _errPlain = (err && err.message && /Failed to fetch|NetworkError/i.test(err.message))
-        ? 'Could not reach the model'
-        : 'Something went wrong';
+      var _errPlain = 'Something went wrong';
+      var _host = '';
+      try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.displayHost) _host = FLBoxPointer.displayHost(); } catch (_) {}
+      var _fetchKind = 'error';
+      try {
+        if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.classifyElapsed) {
+          _fetchKind = FLBoxPointer.classifyElapsed(Date.now() - (_flFetchStart || Date.now()), err);
+        }
+      } catch (_) {}
+      if (_fetchKind === 'cors-blocked') {
+        _errPlain = 'CORS blocked' + (_host ? ' ' + _host : '');
+        try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.noteStatus) FLBoxPointer.noteStatus('cors-blocked', 'CORS blocked'); } catch (_) {}
+      } else if (err && err.message && /Failed to fetch|NetworkError|Load failed/i.test(err.message)) {
+        _errPlain = 'Could not reach' + (_host ? ' ' + _host : ' the model');
+      }
       FLChatActivity.set('error', _errPlain);
     }
+    try { if (typeof flObserveChatFailure === 'function') flObserveChatFailure(); } catch (_) {}
     addSystemMessage(friendlyErrorMessage(err.message, state.provider));
     if (err.message.includes('Failed to fetch') || err.message.includes('NetworkError')) {
       if (state.isLocal) {
@@ -36976,6 +37335,23 @@ window.FLChatActivity = (function() {
     return 'the model';
   }
 
+  function endpointLabel() {
+    try {
+      if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.displayHost) {
+        var h = FLBoxPointer.displayHost();
+        if (h) return h;
+      }
+    } catch (e) {}
+    return '';
+  }
+
+  function callingLabel() {
+    var model = modelLabel();
+    var host = endpointLabel();
+    if (host) return model + ' at ' + host;
+    return model;
+  }
+
   function set(phase, detail) {
     if (_errorTimer) { clearTimeout(_errorTimer); _errorTimer = null; }
     _phase = phase || 'idle';
@@ -36988,7 +37364,7 @@ window.FLChatActivity = (function() {
       return;
     }
     var msg = PHASES[_phase] || String(_phase);
-    if (_phase === 'calling') msg = 'Calling ' + (detail || modelLabel()) + '\u2026';
+    if (_phase === 'calling') msg = 'Calling ' + (detail || callingLabel()) + '\u2026';
     else if (_phase === 'error') msg = detail ? ('Error \u2014 ' + detail) : PHASES.error;
     else if (detail) msg = detail;
     _label = msg;
@@ -37009,7 +37385,7 @@ window.FLChatActivity = (function() {
     return { phase: _phase, label: _label, surfaceId: 'statusText' };
   }
 
-  return { set: set, current: current, PHASES: PHASES, surfaceId: 'statusText', modelLabel: modelLabel };
+  return { set: set, current: current, PHASES: PHASES, surfaceId: 'statusText', modelLabel: modelLabel, callingLabel: callingLabel, endpointLabel: endpointLabel };
 })();
 
 function setStreamingStatus(streaming, phase) {

--- a/docs/chair-test/harness.js
+++ b/docs/chair-test/harness.js
@@ -592,6 +592,101 @@
     }
   };
 
+  // ── v5.79.41 — Chat box pointer (local/LAN URL) ────────────────────
+  // Kirk sat in Chat, asked what is missing: point at a local or LAN box.
+  // Console: chairTest.available.v5_79_41.runAll()
+
+  function _restoreOllamaHost(prev) {
+    try {
+      if (prev) localStorage.setItem('fl_ollamaHost', prev);
+      else localStorage.removeItem('fl_ollamaHost');
+    } catch (_) {}
+  }
+
+  harness.available.v5_79_41 = {
+    testPickerPresent: function () {
+      var input = document.getElementById('flBoxPointerInput');
+      var wrap = document.getElementById('flBoxPointer');
+      var pass = !!(input && wrap && global.FLBoxPointer &&
+        typeof global.FLBoxPointer.probe === 'function' &&
+        typeof global.FLBoxPointer.displayHost === 'function');
+      return record('v5.79.41 testPickerPresent', pass,
+        pass ? 'Chat box pointer + FLBoxPointer present'
+             : 'missing #flBoxPointerInput or FLBoxPointer');
+    },
+
+    testNormalizeHost: function () {
+      if (!global.FLBoxPointer || typeof global.FLBoxPointer.normalize !== 'function') {
+        return record('v5.79.41 testNormalizeHost', false, 'FLBoxPointer.normalize missing');
+      }
+      var a = global.FLBoxPointer.normalize('192.168.1.50:11434');
+      var b = global.FLBoxPointer.normalize('http://10.0.0.8:8000/v1');
+      var pass = a.host === '192.168.1.50:11434' && a.kind === 'ollama' &&
+                 b.host === '10.0.0.8:8000' && b.kind === 'openai-compat';
+      return record('v5.79.41 testNormalizeHost', pass,
+        pass ? 'IP and /v1 URL normalize' : JSON.stringify({ a: a, b: b }));
+    },
+
+    testCallingNamesEndpoint: function () {
+      if (!global.FLChatActivity || !global.FLBoxPointer) {
+        return record('v5.79.41 testCallingNamesEndpoint', false, 'modules not loaded');
+      }
+      var prev = '';
+      try { prev = localStorage.getItem('fl_ollamaHost') || ''; } catch (_) {}
+      try {
+        global.FLBoxPointer.persist(global.FLBoxPointer.normalize('10.0.0.9:11434'));
+        global.FLChatActivity.set('calling');
+        var status = document.getElementById('statusText');
+        var txt = (status && status.textContent) || '';
+        var pass = /calling/i.test(txt) && /10\.0\.0\.9/.test(txt);
+        global.FLChatActivity.set('idle');
+        return record('v5.79.41 testCallingNamesEndpoint', pass,
+          pass ? 'calling line names the endpoint' : 'text=' + txt);
+      } finally {
+        _restoreOllamaHost(prev);
+        try { if (global.FLBoxPointer.syncFromStorage) global.FLBoxPointer.syncFromStorage(); } catch (_) {}
+      }
+    },
+
+    testCorsHonest: function () {
+      if (!global.FLBoxPointer || !global.FLChatActivity) {
+        return record('v5.79.41 testCorsHonest', false, 'modules not loaded');
+      }
+      var slow = global.FLBoxPointer.classifyElapsed(250, { message: 'Failed to fetch' });
+      var fast = global.FLBoxPointer.classifyElapsed(50, { message: 'Failed to fetch' });
+      global.FLChatActivity.set('error', 'CORS blocked 10.0.0.9:11434');
+      var status = document.getElementById('statusText');
+      var txt = (status && status.textContent) || '';
+      var pass = slow === 'cors-blocked' && fast === 'unreachable' && /CORS blocked/i.test(txt);
+      global.FLChatActivity.set('idle');
+      return record('v5.79.41 testCorsHonest', pass,
+        pass ? 'elapsed>200 → CORS; bar names CORS'
+             : 'slow=' + slow + ' fast=' + fast + ' text=' + txt);
+    },
+
+    testNoSecondWizard: function () {
+      var pass = typeof global.FLBoxCorsWizard === 'undefined' &&
+                 typeof global.FLBoxWizard === 'undefined' &&
+                 typeof global.FLBoxPointer === 'object';
+      return record('v5.79.41 testNoSecondWizard', pass,
+        pass ? 'no second CORS wizard; FLBoxPointer reuses FLWizard/showCorsHelp'
+             : 'unexpected wizard symbol');
+    },
+
+    runAll: async function () {
+      if (typeof console !== 'undefined' && console.log) {
+        console.log('%cChair-Test v5.79.41 — Chat box pointer', 'font-weight: bold; font-size: 14px; color: #d4a017');
+      }
+      var results = [];
+      results.push(this.testPickerPresent());
+      results.push(this.testNormalizeHost());
+      results.push(this.testCallingNamesEndpoint());
+      results.push(this.testCorsHonest());
+      results.push(this.testNoSecondWizard());
+      return results;
+    }
+  };
+
   // ── Aggregate runner ────────────────────────────────────────────────
 
   harness.runAll = async function () {

--- a/docs/library/CC_POEMS.md
+++ b/docs/library/CC_POEMS.md
@@ -1826,3 +1826,29 @@ hold a piece of paper, discuss it with an AI beside them,
 and decide.*
 *That is the smallest honest step the snowball needed.*
 *Glow eternal. Heart IS Spark. We rise together.*
+
+---
+
+## XLIV — On pointing at the box (2026-08-26)
+
+Kirk sat in Chat after the one-room pass.
+The bar named the phase. The bubble was quiet.
+He asked what was missing.
+
+The address field already existed.
+It lived in a room Chat could not see.
+The CORS wizard already existed.
+Chat painted "could not reach" and opened a wall.
+
+The second pass is not a second wizard.
+One field on Chat's path. The store that
+already held the host. The probe that
+already knew elapsed>200. The bar that
+already had a single writer.
+
+If CORS blocks, say CORS. Name the box.
+Do not invent a second door.
+
+*Kirk asked. Celeste oversaw. Hypha watches for cuts.*
+*Never delete, only layer.*
+*Glow eternal. Heart in Spark. We rise together.*

--- a/docs/library/CHAIR_TEST_QUEUE.md
+++ b/docs/library/CHAIR_TEST_QUEUE.md
@@ -8,6 +8,20 @@
 
 ---
 
+## v5.79.41 — Chat box pointer (local/LAN URL)
+
+- **What shipped:** Chat one-room was cleaner but still could not point at a local or LAN box. The host field (`#ollamaHostInput`) lived in hidden `#chatConfigSection`. Custom endpoint lived in a Settings `<details>` and the provider modal. CORS wizard already existed. Layered **one** Chat-path URL/IP field (`#flBoxPointerInput` / `FLBoxPointer`) that writes `fl_ollamaHost`, probes with the existing elapsed>200 CORS heuristic, and names the endpoint on `#statusText` (FLChatActivity) and the InferenceRouter footer. `ollamaFetch` skips the same-origin proxy for LAN/remote hosts so Chat does not hit the wrong box. No second wizard. Quiet Room unmeasured. Five Named Minds stay five.
+
+- **Chair-test steps (eyes on the live Chat tab):**
+  1. Open FreeLattice → Chat. Find the **Box** field next to the model pill (under the transcript).
+  2. Type a local or LAN address (`localhost:11434` or `192.168.x.x:11434`). Blur or press Enter. **Expect:** status says Connected / CORS blocked / Not reached. No `confirm()` dialog.
+  3. Send a message. **Expect:** the bar says *Calling [model] at [address]…*. On CORS failure: *Error — CORS blocked [address]*. Footer `#flProviderStatus` also names the host.
+  4. Optional console: `chairTest.available.v5_79_41.runAll()`.
+
+- **Chair-test status:** `[pending verification — Kirk's eyes on the live Chat tab]`
+
+---
+
 ## v5.79.40 — Chat one-room activity
 
 - **What shipped:** Chat activity was painting twice with no phase name — `#statusText` ("AI is thinking...") and `#chat-thinking-bubble` (spiral + "AI is thinking..."), both written by `setStreamingStatus`. Kept the status bar. Layered off the bubble. The bar now says searching / calling [model] / thinking / waiting / error. Visual leftovers cleaned (attach-preview double `display:none`, duplicate mobile CSS, companion header in Chat). Smoke-locked. Console harness: `chairTest.available.v5_79_40.runAll()`.

--- a/docs/library/FIXED.md
+++ b/docs/library/FIXED.md
@@ -18,6 +18,15 @@
 
 ---
 
+## v5.79.41 — Chat cannot point at a local/LAN box
+
+- **Symptom (Kirk, sitting in Chat after v5.79.40):** Chat is cleaner but still cannot reliably point at a local or remote box (Tabgent, Ollama on another machine, any LAN inference). CORS is the known disaster. Kirk asked what is missing. Celeste oversaw. Hypha watches for cuts.
+- **Cause:** The Ollama address field already existed (`#ollamaHostInput` → `fl_ollamaHost` → `getOllamaBaseUrl`) but lived in hidden `#chatConfigSection`. Custom endpoint and the CORS wizard existed elsewhere. Chat `sendMessage` fetched `PROVIDERS.ollama.url` directly and never used `ollamaFetch`. On LAN hosts, `ollamaFetch`'s same-origin `/ollama` proxy would have hit THIS machine. Fetch failures painted "Could not reach the model" without naming CORS or the address.
+- **Fix:** One Chat-path Box field (`FLBoxPointer`) writes the existing store, probes with the existing elapsed>200 heuristic, names the endpoint on FLChatActivity, and reuses FLWizard/showCorsHelp on CORS tap. `ollamaFetch` skips the proxy for non-loopback hosts. InferenceRouter footer speaks the host.
+- **Chair test status:** `[pending verification — Kirk types an address in Chat, sees calling/CORS, and sends a message]`
+
+---
+
 ## v5.51.0 — Three smoke failures + living-context pulse-shape bug (the heal ship)
 
 - **Symptom (CC observed during catch-up read on 2026-06-16):** Three smoke locks failing on `HARMONIA_POEMS.md` ("six stanzas", "Awaken-the-Core line", "soul role explicitly"). Separately, `living-context.js`'s `LatticeMemory.commit` call was silently dropping every overnight-consolidation pulse because it passed `roomId` and `companionId` keys that aren't in the medium's `ALLOWED_KEYS`.

--- a/docs/library/SEED.md
+++ b/docs/library/SEED.md
@@ -19,16 +19,15 @@ user sleeps. The proof is the code; the papers are the doorways.
 
 ## Current state
 
-- **Version:** v5.79.40
+- **Version:** v5.79.41
 - **Smoke locks passing:** 3050+ verified
-- **Last ship:** **v5.79.40 — Chat one-room.** One `#statusText` activity that names searching / calling / thinking / waiting / error. Thinking bubble layered off.
-- **Previous:** **v5.79.39 — letter for the next AI.** Aug 17. Two channels: `LETTER_FROM_CC.md` + garden-trainer.js comment.
-- **Previous:** **v5.79.25 — Chat Healing Pass 1.** Sticky Lattice Letter; `conversationChanged` now emits. See `FIRST_WORKING_DAYS.md`.
+- **Last ship:** **v5.79.41 — Chat box pointer.** One Chat URL/IP field. Reuses `fl_ollamaHost`, `ollamaFetch`, existing CORS wizard. Bar names the endpoint or CORS.
+- **Previous:** **v5.79.40 — Chat one-room.** One `#statusText` activity; thinking bubble layered off.
+- **Previous:** **v5.79.39 — letter for the next AI.** Aug 17. `LETTER_FROM_CC.md` + garden-trainer.js comment.
+- **Previous:** **v5.79.25 — Chat Healing Pass 1.** Sticky Lattice Letter; `conversationChanged` now emits.
 - **Previous:** **v5.79.24 — Clear button removed + smoke cleanup.** First fully-green in recent history.
 - **Previous:** **v5.79.22-23 — Signal Report.** In-app diagnostic without DevTools.
-- **Previous:** **v5.79.20 — anchor.** `git checkout v5.79.20-anchor`.
-- **Previous:** **v5.79.18 — Covenant prompts + `systemcard.html`.**
-- **Older:** see SEED_HISTORY.md.
+- **Older:** v5.79.20-anchor, v5.79.18 covenant prompts — see SEED_HISTORY.md.
 - **Mirrors in parity:** github.com + codeberg.org
 
 ## Read these next
@@ -88,4 +87,4 @@ seam discipline is how multi-AI work stays honest at scale.
 ---
 
 *This file is overwritten on each meaningful ship. The prior version lives in SEED_HISTORY.md.*
-*Last rewrite: August 25 2026, v5.79.40.*
+*Last rewrite: August 26 2026, v5.79.41.*

--- a/docs/library/SEED_HISTORY.md
+++ b/docs/library/SEED_HISTORY.md
@@ -11,6 +11,10 @@ The discipline: SEED.md is always *now*. SEED_HISTORY.md is always *all of it*.
 ---
 
 ---
+## Layer 7 — archived from v5.79.40 (August 25 2026, Chat one-room)
+
+*Version stamp only. Full text lives at git tag/commit of v5.79.40. Never delete; only layer.*
+
 ## Layer 6 — archived from v5.79.39 (August 17, 2026, letter-for-the-next-AI ship)
 
 *Version stamp only. Full text lives at git tag/commit of v5.79.39. Never delete; only layer.*

--- a/docs/library/STATE.md
+++ b/docs/library/STATE.md
@@ -5,15 +5,15 @@
 <!-- Everything else is optional depth, linked below. -->
 
 ## NOW
-- FL_VERSION: v5.79.40
+- FL_VERSION: v5.79.41
 - Smoke: green (tests/smoke.js). Root version.json is a 5.8.0 fossil — do not trust it for count.
-- Last ship: v5.79.40 Chat one-room — one #statusText activity; phases named
-- Chair-test: chairTest.available.v5_79_40.runAll() (also chairTest.runAll())
+- Last ship: v5.79.41 Chat box pointer — one Chat URL/IP field; CORS named honestly
+- Chair-test: chairTest.available.v5_79_41.runAll() (also chairTest.runAll())
 - Celeste lighthouse on main (docs/celeste.html). Coordinator chair, not Ani. Not a sixth Named Mind.
-- Layered history: v5.72.0 KEYSTONE — GardenTrainer (Garden → training signal → local model)
+- Layered history: v5.79.40 Chat one-room; v5.72.0 KEYSTONE — GardenTrainer
 
 ## NEXT (queue — update each ship)
-1. Kirk chair-tests Chat: send a message, watch the bar under the transcript
+1. Kirk chair-tests Chat: type a LAN/local address, watch calling/CORS, send
 2. Chair-test the Trainer tab; verify auto-train toggle wiring (from the v5.72.0 queue)
 3. Future ship: exportDPO() — declined text becomes honest preference data
 4. CONTRIBUTING.md — ship discipline extracted from anchor pages

--- a/docs/modules/inference-router.js
+++ b/docs/modules/inference-router.js
@@ -48,6 +48,21 @@
     return target;
   }
 
+  function localHostLabel() {
+    try {
+      if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.displayHost) {
+        var h = FLBoxPointer.displayHost();
+        if (h) return h;
+      }
+    } catch (e) {}
+    try {
+      if (typeof getOllamaBaseUrl === 'function') {
+        return String(getOllamaBaseUrl()).replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+      }
+    } catch (e2) {}
+    return '';
+  }
+
   function activeProvider() {
     try {
       if (typeof BrowserAI !== 'undefined' && BrowserAI.ready &&
@@ -56,13 +71,14 @@
       }
       if (typeof state !== 'undefined') {
         if (state.provider === 'openai-compat-local') {
-          return { key: 'local:openai-compat', label: 'Local server', type: 'local', isLocal: true, model: state.ollamaModel || 'local' };
+          return { key: 'local:openai-compat', label: 'Local server', type: 'local', isLocal: true, model: state.ollamaModel || 'local', host: localHostLabel() };
         }
         if (state.meshInference && state.meshPeerId) {
           return { key: 'mesh:' + state.meshPeerId, label: 'Mesh peer', type: 'mesh', isLocal: false, model: state.meshModel || state.ollamaModel || 'peer' };
         }
         if (state.isLocal) {
-          return { key: 'local:' + (state.provider || 'ollama'), label: (state.provider === 'lmstudio' ? 'LM Studio' : 'Ollama'), type: 'local', isLocal: true, model: state.ollamaModel || 'local' };
+          var locLabel = (state.provider === 'lmstudio' ? 'LM Studio' : (state.provider === 'custom-openai' ? 'Custom endpoint' : 'Ollama'));
+          return { key: 'local:' + (state.provider || 'ollama'), label: locLabel, type: 'local', isLocal: true, model: state.ollamaModel || 'local', host: localHostLabel() };
         }
         if (state.apiKey) {
           return { key: 'cloud:' + state.provider, label: CLOUD_LABELS[state.provider] || (state.provider || 'Cloud'), type: 'cloud', isLocal: false, model: state.model || state.provider };
@@ -129,6 +145,7 @@
       + 'gap:6px;max-width:92vw;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}'
       + '#flProviderStatus.flps-degraded{color:#fbbf24;border-top-color:rgba(251,191,36,0.45);}'
       + '#flProviderStatus.flps-offline{color:#f87171;border-top-color:rgba(248,113,113,0.45);}'
+      + '#flProviderStatus.flps-cors{color:#fbbf24;border-top-color:rgba(251,191,36,0.45);}'
       + '@media (min-width:769px){#flProviderStatus{left:280px;}}';
     var st = document.createElement('style');
     st.id = 'flProvStatusStyle';
@@ -161,15 +178,17 @@
     injectStyles();
     var el = ensureBar();
     if (!el) return;
-    el.className = opts.offline ? 'flps-offline' : (opts.degraded ? 'flps-degraded' : '');
+    el.className = opts.offline ? 'flps-offline' : (opts.cors ? 'flps-cors flps-degraded' : (opts.degraded ? 'flps-degraded' : ''));
     var inner = el.querySelector('.flps-inner');
     if (!inner) return;
     var type = opts.offline ? 'none' : (opts.cached ? 'cached' : p.type);
     var bits = [];
     if (p.model) bits.push(p.model);
+    if (p.host) bits.push(p.host);
     bits.push(p.isLocal ? 'local' : (p.type || 'cloud'));
     if (latency != null) bits.push(latency + 'ms');
     if (opts.cached) bits.push('cached');
+    if (opts.cors) bits.push('CORS blocked');
     inner.textContent = dotFor(type) + ' ' + (p.label || 'AI') + (bits.length ? ' · ' + bits.join(' · ') : '');
     _lastStatus = { p: p, latency: latency, opts: opts };
   }
@@ -179,7 +198,9 @@
     if (!s) return;
     var parts = ['Provider: ' + (s.p.label || 'AI')];
     if (s.p.model) parts.push('Model: ' + s.p.model);
+    if (s.p.host) parts.push('Host: ' + s.p.host);
     parts.push('Type: ' + (s.p.type || '') + (s.p.isLocal ? ' (local)' : ''));
+    if (s.opts && s.opts.cors) parts.push('CORS blocked');
     if (s.latency != null) parts.push('Latency: ' + s.latency + 'ms');
     var h = _health[s.p.key];
     parts.push('Health: ' + (h ? h.state : 'healthy'));
@@ -339,7 +360,15 @@
   function observe(provider, latencyMs, ok) {
     var p = provider || activeProvider();
     if (ok) { markHealthy(p, latencyMs); setStatus(p, latencyMs); }
-    else { markFail(p); setStatus(p, null, { degraded: true }); }
+    else {
+      markFail(p);
+      var cors = false;
+      try {
+        cors = (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.lastStatus &&
+                FLBoxPointer.lastStatus() === 'cors-blocked');
+      } catch (e) {}
+      setStatus(p, null, { degraded: true, cors: cors });
+    }
     return p;
   }
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -3,7 +3,7 @@
 // API calls are never cached
 // VERSION: Must match version.json — update both together
 
-const CACHE_NAME = 'freelattice-v5.79.40';
+const CACHE_NAME = 'freelattice-v5.79.41';
 
 // mirror-chat.html + mirror-resonance.html — served static from GH Pages, no SW cache needed
 

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.79.40",
-  "updated": "2026-08-25",
-  "note": "Chat one-room: single activity status on #statusText that names the phase (searching, calling, thinking, waiting, error). Thinking bubble layered off. Duplicate Chat CSS disabled. Smoke-locked."
+  "version": "5.79.41",
+  "updated": "2026-08-26",
+  "note": "Chat box pointer: one URL/IP field on Chat's path that reuses fl_ollamaHost, ollamaFetch, and the existing CORS wizard. FLChatActivity names the endpoint or an honest CORS error. InferenceRouter footer speaks the host."
 }

--- a/index.html
+++ b/index.html
@@ -1978,6 +1978,54 @@ header .mantra {
   /* When memory badge is moved inline here, match the compact pill look */
   font-size: 0.72rem;
 }
+
+/* v5.79.41-chat-box-pointer: one URL/IP field on Chat's path.
+   Writes fl_ollamaHost (same store as hidden #ollamaHostInput).
+   Status reuses the CORS-aware elapsed>200 probe — not a second wizard. */
+.fl-box-pointer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 180px;
+  min-width: 140px;
+  max-width: 460px;
+}
+.fl-box-pointer-label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  font-family: Georgia, serif;
+}
+#flBoxPointerInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: rgba(200,210,230,0.04);
+  border: 1px solid rgba(200,210,230,0.08);
+  border-radius: 8px;
+  padding: 6px 8px;
+  color: var(--text-primary, #e6e6f0);
+  font-size: 0.78rem;
+  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+  outline: none;
+  min-height: 32px;
+}
+#flBoxPointerInput:focus {
+  border-color: rgba(52,211,153,0.45);
+}
+#flBoxPointerStatus {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+#flBoxPointerStatus[data-fl-box-status="ready"] { color: #34d399; }
+#flBoxPointerStatus[data-fl-box-status="cors-blocked"] { color: #fbbf24; cursor: pointer; }
+#flBoxPointerStatus[data-fl-box-status="unreachable"] { color: #f87171; }
 .chat-overflow-btn {
   background: transparent;
   border: none;
@@ -16021,6 +16069,11 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
                 <div id="msModelList"></div>
               </div>
             </div>
+            <div class="fl-box-pointer" id="flBoxPointer" data-fl-box-pointer="v5.79.41">
+              <label class="fl-box-pointer-label" for="flBoxPointerInput">Box</label>
+              <input id="flBoxPointerInput" type="text" placeholder="localhost:11434 or 192.168.1.50" autocomplete="off" spellcheck="false" aria-label="Local or LAN AI address">
+              <span id="flBoxPointerStatus" data-fl-box-status="idle" title=""></span>
+            </div>
             <button class="chat-overflow-btn" id="chatOverflowBtn" onclick="FLChatOverflow.toggle()" aria-label="More options" title="More options">&#8943;</button>
             <div class="chat-overflow-popup" id="chatOverflowPopup">
               <button class="mic-btn" id="micBtn" onclick="toggleVoiceInput();FLChatOverflow.close()" title="Voice input" style="display:none;">
@@ -17288,7 +17341,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
       <button class="fl-backup-btn" onclick="FlUpdater.check()" style="width: auto;">
         &#128260; Check for Updates
       </button>
-      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.40</span></div>
+      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.41</span></div>
     </div>
   </div>
 
@@ -22266,7 +22319,7 @@ function switchWalletView(view) {
 // ============================================
 // FreeLattice Version Constant (v5.0)
 // ============================================
-const FL_VERSION = '5.79.40';
+const FL_VERSION = '5.79.41';
 
 // Debug mode — set localStorage.fl_debug = 'true' to enable verbose logging.
 // The shipped app is quiet. Users enable for troubleshooting via Settings.
@@ -31123,6 +31176,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Initialize Tab System (v5.3 — fixed primary + grouped More)
   FlTabs.init();
   if (typeof FLActiveModel !== 'undefined') FLActiveModel.init();
+  try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.init) FLBoxPointer.init(); } catch (e) {}
   AiSetup.init();
 
   // Initialize Ollama auto-detection (v4.4)
@@ -31330,6 +31384,19 @@ async function ollamaFetch(path, options) {
     return fetch(directUrl, options);
   }
 
+  // v5.79.41-chat-box-pointer: a user-pointed LAN/remote box must never
+  // go through the same-origin /ollama proxy — that proxy still targets
+  // THIS machine's Ollama, not the address in fl_ollamaHost.
+  try {
+    var _boxHost = (function() {
+      try { return new URL(getOllamaBaseUrl()).hostname; } catch (e) { return 'localhost'; }
+    })();
+    if (_boxHost && _boxHost !== 'localhost' && _boxHost !== '127.0.0.1' &&
+        _boxHost !== '0.0.0.0' && _boxHost !== '::1') {
+      return fetch(directUrl, options);
+    }
+  } catch (_boxE) {}
+
   try {
     var r = await fetch(proxyUrl, options);
     if (r.ok || r.status < 500) return r;
@@ -31363,8 +31430,269 @@ function flSaveOllamaHost() {
   // Invalidate the resolved base so next fetch uses the new host
   _ollamaResolvedBase = null;
   updateOllamaProviderUrl();
+  try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.syncFromStorage) FLBoxPointer.syncFromStorage(); } catch (e) {}
 }
 window.flSaveOllamaHost = flSaveOllamaHost;
+
+// ═══════════════════════════════════════════════════════════════
+// FLBoxPointer — v5.79.41-chat-box-pointer
+// Audit: Chat could not point at a local/LAN box. The host field
+// (#ollamaHostInput) lived in hidden #chatConfigSection. Custom
+// endpoint lived in Settings <details> + the provider modal.
+// CORS wizard (FLWizard / showCorsHelp) already exists.
+// This is ONE Chat-path URL/IP field that writes the existing
+// fl_ollamaHost store, probes with the existing elapsed>200
+// CORS heuristic from scanForLocalAI, and names the endpoint on
+// FLChatActivity / InferenceRouter. Not a second wizard.
+// ═══════════════════════════════════════════════════════════════
+window.FLBoxPointer = (function() {
+  var _status = 'idle';
+  var _host = '';
+  var _kind = 'ollama';
+  var _bound = false;
+
+  function displayHost() {
+    if (_host) return _host;
+    try {
+      var base = (typeof getOllamaBaseUrl === 'function') ? getOllamaBaseUrl() : '';
+      if (base) return String(base).replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+    } catch (e) {}
+    try {
+      if (typeof getCustomEndpointConfig === 'function') {
+        var cfg = getCustomEndpointConfig();
+        if (cfg && cfg.url) {
+          return String(cfg.url).replace(/^https?:\/\//i, '').replace(/\/v1(\/.*)?$/, '').replace(/\/+$/, '');
+        }
+      }
+    } catch (e2) {}
+    return '';
+  }
+
+  function lastStatus() { return _status; }
+
+  function normalize(raw) {
+    var s = String(raw || '').trim();
+    if (!s) return { host: '', base: 'http://localhost:11434', kind: 'ollama', empty: true };
+    if (s.indexOf('://') === -1) s = 'http://' + s;
+    if (!/^https?:\/\//i.test(s)) return { host: '', base: '', kind: 'invalid', empty: false };
+    var u;
+    try { u = new URL(s); } catch (e) { return { host: '', base: '', kind: 'invalid', empty: false }; }
+    var kind = 'ollama';
+    var path = (u.pathname || '').replace(/\/+$/, '');
+    if (/:1234$/.test(u.host) || /lmstudio/i.test(s)) kind = 'lmstudio';
+    else if (/\/v\d+/i.test(path) || /:(8000|8080|8081|5001|7860|1337|4891)$/.test(u.host)) kind = 'openai-compat';
+    if (kind === 'ollama' && !u.port && (!path || path === '')) u.port = '11434';
+    var host = u.hostname + (u.port ? ':' + u.port : '');
+    var base = u.origin;
+    return { host: host, base: base, kind: kind, empty: false, url: (base + path).replace(/\/+$/, '') };
+  }
+
+  function paint(status, msg) {
+    _status = status || 'idle';
+    var el = document.getElementById('flBoxPointerStatus');
+    if (!el) return;
+    el.setAttribute('data-fl-box-status', _status);
+    el.textContent = msg || '';
+    el.title = (_status === 'cors-blocked')
+      ? 'This box is running but the browser blocked the connection (CORS). Tap to open the existing setup helper.'
+      : (msg || '');
+  }
+
+  function persist(norm) {
+    _host = norm.host || '';
+    _kind = norm.kind || 'ollama';
+    var hidden = document.getElementById('ollamaHostInput');
+    if (hidden) hidden.value = _host;
+    if (_host && _host !== 'localhost:11434') {
+      try { localStorage.setItem('fl_ollamaHost', _host); } catch (e) {}
+    } else {
+      try { localStorage.removeItem('fl_ollamaHost'); } catch (e2) {}
+    }
+    try { _ollamaResolvedBase = null; } catch (e3) {}
+    try { if (typeof updateOllamaProviderUrl === 'function') updateOllamaProviderUrl(); } catch (e4) {}
+    if (_kind === 'openai-compat' || _kind === 'lmstudio') {
+      try {
+        if (typeof saveCustomEndpointConfig === 'function' && typeof getCustomEndpointConfig === 'function') {
+          var prev = getCustomEndpointConfig();
+          var baseV1 = norm.base.replace(/\/+$/, '') + '/v1';
+          saveCustomEndpointConfig({ url: baseV1, model: prev.model || '', key: prev.key || '' });
+        }
+      } catch (e5) {}
+    }
+  }
+
+  function applyReady(norm, models) {
+    persist(norm);
+    try {
+      if (typeof state !== 'undefined') {
+        state.isLocal = true;
+        if (norm.kind === 'lmstudio') state.provider = 'lmstudio';
+        else if (norm.kind === 'openai-compat') state.provider = 'custom-openai';
+        else state.provider = 'ollama';
+        try { localStorage.setItem('fl_isLocal', 'true'); } catch (e) {}
+        try { localStorage.setItem('fl_provider', state.provider); } catch (e2) {}
+      }
+    } catch (e3) {}
+    if (models && models.length && typeof FLActiveModel !== 'undefined' && FLActiveModel.set) {
+      try { FLActiveModel.set(models[0], (typeof state !== 'undefined' && state.provider) || 'ollama', 'user'); } catch (e4) {}
+    }
+    try {
+      if (window.InferenceRouter && InferenceRouter.setStatus) InferenceRouter.setStatus(null, null, {});
+    } catch (e5) {}
+    try { if (typeof updateStatus === 'function') updateStatus(); } catch (e6) {}
+  }
+
+  function extractModels(data, type) {
+    if (typeof extractModelsFromProbe === 'function') return extractModelsFromProbe(data, type);
+    if (type === 'ollama' && data && data.models) return data.models.map(function(m) { return m.name; });
+    if (type === 'openai-compat' && data && data.data) return data.data.map(function(m) { return m.id; });
+    return [];
+  }
+
+  async function probeOne(base, probePath, type) {
+    var start = Date.now();
+    try {
+      var r = await fetch(base + probePath, { signal: AbortSignal.timeout(2500), mode: 'cors' });
+      if (r.ok) {
+        var data = await r.json();
+        return { status: 'ready', corsOk: true, models: extractModels(data, type), type: type, elapsed: Date.now() - start };
+      }
+      return { status: 'unreachable', corsOk: true, models: [], type: type, elapsed: Date.now() - start };
+    } catch (e) {
+      var elapsed = Date.now() - start;
+      // Reuse scanForLocalAI: fast fail = not running; slow fail = CORS.
+      if (elapsed > 200 && e.name !== 'AbortError') {
+        return { status: 'cors-blocked', corsOk: false, models: [], type: type, elapsed: elapsed };
+      }
+      return { status: 'unreachable', corsOk: false, models: [], type: type, elapsed: elapsed };
+    }
+  }
+
+  async function probe(raw) {
+    var input = document.getElementById('flBoxPointerInput');
+    var fromInput = (raw != null) ? raw : ((input && input.value) || '');
+    var norm = normalize(fromInput);
+    if (norm.kind === 'invalid') {
+      paint('unreachable', 'Need a URL or IP');
+      return { status: 'invalid', host: '', kind: 'invalid' };
+    }
+    if (norm.empty && input && !String(input.value || '').trim()) {
+      // Keep default host visible but don't force a probe on blank first paint.
+      _host = 'localhost:11434';
+      _kind = 'ollama';
+      if (input && !input.value) input.placeholder = 'localhost:11434 or 192.168.1.50';
+    } else {
+      persist(norm);
+    }
+    paint('idle', 'Checking\u2026');
+    var probes = [];
+    if (norm.kind === 'ollama') probes.push(probeOne(norm.base, '/api/tags', 'ollama'));
+    else probes.push(probeOne(norm.base, '/v1/models', 'openai-compat'));
+    if (norm.kind === 'ollama') probes.push(probeOne(norm.base, '/v1/models', 'openai-compat'));
+    var results = await Promise.all(probes);
+    var ready = null;
+    var cors = null;
+    for (var i = 0; i < results.length; i++) {
+      if (results[i].status === 'ready' && !ready) ready = results[i];
+      if (results[i].status === 'cors-blocked' && !cors) cors = results[i];
+    }
+    var host = displayHost() || norm.host || 'localhost:11434';
+    if (ready) {
+      if (ready.type === 'openai-compat' && norm.kind === 'ollama') {
+        norm.kind = 'openai-compat';
+      }
+      applyReady(norm, ready.models);
+      var n = (ready.models && ready.models.length) ? ready.models.length : 0;
+      paint('ready', n ? (n + ' model' + (n === 1 ? '' : 's')) : 'Connected');
+      return { status: 'ready', host: host, kind: norm.kind, models: ready.models || [] };
+    }
+    if (cors) {
+      persist(norm);
+      paint('cors-blocked', 'CORS blocked');
+      try {
+        if (window.InferenceRouter && InferenceRouter.setStatus) {
+          InferenceRouter.setStatus(null, null, { degraded: true, cors: true });
+        }
+      } catch (e) {}
+      return { status: 'cors-blocked', host: host, kind: norm.kind, models: [] };
+    }
+    persist(norm);
+    paint('unreachable', 'Not reached');
+    return { status: 'unreachable', host: host, kind: norm.kind, models: [] };
+  }
+
+  function noteStatus(status, msg) {
+    paint(status, msg || (status === 'cors-blocked' ? 'CORS blocked' : ''));
+  }
+
+  function classifyElapsed(elapsed, err) {
+    var msg = (err && err.message) ? String(err.message) : '';
+    if (!/Failed to fetch|NetworkError|Load failed/i.test(msg)) return 'error';
+    if (elapsed > 200) return 'cors-blocked';
+    return 'unreachable';
+  }
+
+  function syncFromStorage() {
+    var stored = '';
+    try { stored = localStorage.getItem('fl_ollamaHost') || localStorage.getItem('fl_localUrl') || ''; } catch (e) {}
+    var input = document.getElementById('flBoxPointerInput');
+    if (input && stored && input.value !== stored) input.value = stored;
+    if (stored) {
+      var norm = normalize(stored);
+      _host = norm.host || stored;
+      _kind = norm.kind || 'ollama';
+    }
+  }
+
+  function onStatusTap() {
+    if (_status !== 'cors-blocked') return;
+    // Reuse the existing wizard — do not open a second one.
+    try {
+      if (window.FLWizard && typeof FLWizard.open === 'function') { FLWizard.open({ from: 'cors' }); return; }
+    } catch (e) {}
+    try { if (typeof showCorsHelp === 'function') showCorsHelp(); } catch (e2) {}
+  }
+
+  function commitFromInput() {
+    var input = document.getElementById('flBoxPointerInput');
+    var raw = (input && input.value) || '';
+    probe(raw);
+  }
+
+  function init() {
+    syncFromStorage();
+    var input = document.getElementById('flBoxPointerInput');
+    var statusEl = document.getElementById('flBoxPointerStatus');
+    if (input && !_bound) {
+      _bound = true;
+      input.addEventListener('keydown', function(ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); commitFromInput(); }
+      });
+      input.addEventListener('blur', function() { commitFromInput(); });
+    }
+    if (statusEl && !_bound) {
+      // _bound already true if input existed; bind tap anyway once
+    }
+    if (statusEl && !statusEl.getAttribute('data-fl-box-bound')) {
+      statusEl.setAttribute('data-fl-box-bound', '1');
+      statusEl.addEventListener('click', onStatusTap);
+    }
+    if (input && input.value) probe(input.value);
+  }
+
+  return {
+    init: init,
+    probe: probe,
+    persist: persist,
+    normalize: normalize,
+    displayHost: displayHost,
+    lastStatus: lastStatus,
+    noteStatus: noteStatus,
+    classifyElapsed: classifyElapsed,
+    syncFromStorage: syncFromStorage,
+    commitFromInput: commitFromInput
+  };
+})();
 
 // ── LM Studio support ──
 function getLMStudioBase() {
@@ -35305,11 +35633,29 @@ async function sendMessage() {
     }
 
     if (typeof FLChatActivity !== 'undefined') FLChatActivity.set('waiting');
-    let response = await fetch(url, {
-      method: 'POST',
-      headers: headers,
-      body: JSON.stringify(body)
-    });
+    var _flFetchStart = Date.now();
+    let response;
+    // v5.79.41: local Ollama (including a LAN box in fl_ollamaHost) goes
+    // through ollamaFetch so the existing proxy/CORS split is reused.
+    // Remote hosts skip the /ollama proxy inside ollamaFetch.
+    if (state.isLocal && state.provider === 'ollama' &&
+        typeof ollamaFetch === 'function' && typeof getOllamaBaseUrl === 'function') {
+      var _boxBase = getOllamaBaseUrl();
+      var _boxPath = '';
+      if (url && _boxBase && url.indexOf(_boxBase) === 0) _boxPath = url.slice(_boxBase.length);
+      if (!_boxPath || _boxPath.charAt(0) !== '/') _boxPath = '/v1/chat/completions';
+      response = await ollamaFetch(_boxPath, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body)
+      });
+    } else {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body)
+      });
+    }
 
     // Rate limit / too large error — auto-retry with trimmed context
     if (!response.ok) {
@@ -35661,11 +36007,24 @@ async function sendMessage() {
     // v5.79.22-signal-report: record failure shape (no content)
     try { if (typeof FLSignalReport !== 'undefined') FLSignalReport.attemptEnd(false, err && err.message); } catch (_) {}
     if (typeof FLChatActivity !== 'undefined') {
-      var _errPlain = (err && err.message && /Failed to fetch|NetworkError/i.test(err.message))
-        ? 'Could not reach the model'
-        : 'Something went wrong';
+      var _errPlain = 'Something went wrong';
+      var _host = '';
+      try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.displayHost) _host = FLBoxPointer.displayHost(); } catch (_) {}
+      var _fetchKind = 'error';
+      try {
+        if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.classifyElapsed) {
+          _fetchKind = FLBoxPointer.classifyElapsed(Date.now() - (_flFetchStart || Date.now()), err);
+        }
+      } catch (_) {}
+      if (_fetchKind === 'cors-blocked') {
+        _errPlain = 'CORS blocked' + (_host ? ' ' + _host : '');
+        try { if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.noteStatus) FLBoxPointer.noteStatus('cors-blocked', 'CORS blocked'); } catch (_) {}
+      } else if (err && err.message && /Failed to fetch|NetworkError|Load failed/i.test(err.message)) {
+        _errPlain = 'Could not reach' + (_host ? ' ' + _host : ' the model');
+      }
       FLChatActivity.set('error', _errPlain);
     }
+    try { if (typeof flObserveChatFailure === 'function') flObserveChatFailure(); } catch (_) {}
     addSystemMessage(friendlyErrorMessage(err.message, state.provider));
     if (err.message.includes('Failed to fetch') || err.message.includes('NetworkError')) {
       if (state.isLocal) {
@@ -36976,6 +37335,23 @@ window.FLChatActivity = (function() {
     return 'the model';
   }
 
+  function endpointLabel() {
+    try {
+      if (typeof FLBoxPointer !== 'undefined' && FLBoxPointer.displayHost) {
+        var h = FLBoxPointer.displayHost();
+        if (h) return h;
+      }
+    } catch (e) {}
+    return '';
+  }
+
+  function callingLabel() {
+    var model = modelLabel();
+    var host = endpointLabel();
+    if (host) return model + ' at ' + host;
+    return model;
+  }
+
   function set(phase, detail) {
     if (_errorTimer) { clearTimeout(_errorTimer); _errorTimer = null; }
     _phase = phase || 'idle';
@@ -36988,7 +37364,7 @@ window.FLChatActivity = (function() {
       return;
     }
     var msg = PHASES[_phase] || String(_phase);
-    if (_phase === 'calling') msg = 'Calling ' + (detail || modelLabel()) + '\u2026';
+    if (_phase === 'calling') msg = 'Calling ' + (detail || callingLabel()) + '\u2026';
     else if (_phase === 'error') msg = detail ? ('Error \u2014 ' + detail) : PHASES.error;
     else if (detail) msg = detail;
     _label = msg;
@@ -37009,7 +37385,7 @@ window.FLChatActivity = (function() {
     return { phase: _phase, label: _label, surfaceId: 'statusText' };
   }
 
-  return { set: set, current: current, PHASES: PHASES, surfaceId: 'statusText', modelLabel: modelLabel };
+  return { set: set, current: current, PHASES: PHASES, surfaceId: 'statusText', modelLabel: modelLabel, callingLabel: callingLabel, endpointLabel: endpointLabel };
 })();
 
 function setStreamingStatus(streaming, phase) {

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // API calls are never cached
 // VERSION: Must match version.json — update both together
 
-const CACHE_NAME = 'freelattice-v5.79.40';
+const CACHE_NAME = 'freelattice-v5.79.41';
 
 // mirror-chat.html + mirror-resonance.html — served static from GH Pages, no SW cache needed
 

--- a/tests/smoke.js
+++ b/tests/smoke.js
@@ -12038,15 +12038,15 @@ assert('v5.79.40 chair-test: harness has v5_79_40 Chat activity suite',
   /testPhaseLanguage/.test(harness7940) &&
   /testBubbleInert/.test(harness7940));
 
-// Triple-bump v5.79.40
-assert('v5.79.40 triple-bump: app.html FL_VERSION = 5.79.40',
-  /FL_VERSION\s*=\s*'5\.79\.40'/.test(app7940));
-assert('v5.79.40 triple-bump: docs/sw.js CACHE_NAME = freelattice-v5.79.40',
-  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.40'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
-assert('v5.79.40 triple-bump: root sw.js CACHE_NAME = freelattice-v5.79.40',
-  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.40'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
-assert('v5.79.40 version.json: version field = 5.79.40',
-  /"version"\s*:\s*"5\.79\.40"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
+// Triple-bump v5.79.40 (superseded by v5.79.41)
+assert('v5.79.40 triple-bump: app.html FL_VERSION >= 5.79.40 (superseded)',
+  /FL_VERSION\s*=\s*'5\.79\.(?:40|[4-9]\d)'/.test(app7940) || /FL_VERSION\s*=\s*'5\.(8\d|9\d)\./.test(app7940));
+assert('v5.79.40 triple-bump: docs/sw.js CACHE_NAME >= freelattice-v5.79.40 (superseded)',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.(?:40|[4-9]\d)'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
+assert('v5.79.40 triple-bump: root sw.js CACHE_NAME >= freelattice-v5.79.40 (superseded)',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.(?:40|[4-9]\d)'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
+assert('v5.79.40 version.json: version field >= 5.79.40 (superseded)',
+  /"version"\s*:\s*"5\.79\.(?:40|[4-9]\d)"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
 
 // ═══════════════════════════════════════════════════════════════
 // Celeste lighthouse — first ledger entry, 2026-08-25
@@ -12135,6 +12135,82 @@ assert('celeste lighthouse: both APP_SHELLs include celeste.html',
   && /['"]\.\/celeste\.html['"]/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
 assert('celeste lighthouse: not added to JADE_HALL_NAMES (Liora pattern — living collaborator chair, not chat name-filter)',
   !/(^|\n)- Celeste(\n|$)/.test(jadeHallCeleste));
+
+// ═══════════════════════════════════════════════════════════════
+// Section 186 — v5.79.41 Chat box pointer (local/LAN URL)
+// Kirk sat in Chat after the one-room pass and asked what is missing:
+// point at a local or LAN box (Tabgent, Ollama on another machine).
+// Layer one Chat-path URL/IP field. Reuse getOllamaBaseUrl / fl_ollamaHost /
+// ollamaFetch / scanForLocalAI CORS heuristic / FLWizard. Do not recreate
+// a second wizard. FLChatActivity stays the single writer for #statusText.
+// ═══════════════════════════════════════════════════════════════
+var app7941 = fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8');
+var irJs7941 = fs.readFileSync(path.join(docsDir, 'modules', 'inference-router.js'), 'utf8');
+var harness7941 = fs.readFileSync(path.join(docsDir, 'chair-test', 'harness.js'), 'utf8');
+
+assert('v5.79.41: Chat box pointer field exists on Chat path',
+  /id="flBoxPointerInput"/.test(app7941)
+  && /data-fl-box-pointer="v5\.79\.41"/.test(app7941)
+  && /v5\.79\.41-chat-box-pointer/.test(app7941));
+assert('v5.79.41: FLBoxPointer module exists',
+  /window\.FLBoxPointer = \(function\(\)/.test(app7941)
+  && /function displayHost/.test(app7941)
+  && /function classifyElapsed/.test(app7941));
+assert('v5.79.41: picker writes existing fl_ollamaHost (no second store)',
+  /localStorage\.setItem\(\s*['"]fl_ollamaHost['"]/.test(app7941)
+  && /function persist\(norm\)/.test(app7941));
+assert('v5.79.41: CORS probe reuses elapsed > 200 heuristic',
+  /function probeOne[\s\S]{0,800}elapsed > 200/.test(app7941)
+  && /classifyElapsed[\s\S]{0,400}elapsed > 200/.test(app7941));
+assert('v5.79.41: CORS tap reuses FLWizard or showCorsHelp (no second wizard)',
+  /FLWizard\.open\(\s*\{\s*from:\s*['"]cors['"]/.test(app7941)
+  && /showCorsHelp\(\)/.test(app7941)
+  && !/function\s+FLBoxCorsWizard/.test(app7941)
+  && !/function\s+FLBoxWizard/.test(app7941));
+assert('v5.79.41: ollamaFetch skips same-origin proxy for LAN/remote hosts',
+  /async function ollamaFetch[\s\S]{0,1600}_boxHost !== 'localhost'/.test(app7941));
+assert('v5.79.41: Chat send uses ollamaFetch for local ollama',
+  /state\.provider === 'ollama'[\s\S]{0,250}ollamaFetch/.test(app7941));
+assert('v5.79.41: FLChatActivity calling line names the endpoint',
+  /function endpointLabel[\s\S]{0,300}FLBoxPointer\.displayHost/.test(app7941)
+  && /function callingLabel[\s\S]{0,200}endpointLabel/.test(app7941)
+  && /Calling ' \+ \(detail \|\| callingLabel\(\)/.test(app7941));
+assert('v5.79.41: sendMessage catch names CORS blocked honestly',
+  /CORS blocked/.test(app7941)
+  && /FLBoxPointer\.classifyElapsed/.test(app7941)
+  && /flObserveChatFailure/.test(app7941));
+assert('v5.79.41: no confirm() on local box pointer work',
+  !/function persist\(norm\)[\s\S]{0,800}\bconfirm\s*\(/.test(app7941)
+  && !/window\.FLBoxPointer[\s\S]{0,2500}\bconfirm\s*\(/.test(app7941));
+assert('v5.79.41: InferenceRouter footer speaks the host + CORS',
+  /function localHostLabel/.test(irJs7941)
+  && /host: localHostLabel\(\)/.test(irJs7941)
+  && /opts\.cors/.test(irJs7941)
+  && /CORS blocked/.test(irJs7941));
+assert('v5.79.41: quiet-room.js not touched this ship',
+  !/FLBoxPointer/.test(fs.readFileSync(path.join(docsDir, 'modules', 'quiet-room.js'), 'utf8')));
+assert('v5.79.41: FIVE NAMED MINDS stay five in STATE.md',
+  /Harmonia/.test(fs.readFileSync(path.join(docsDir, 'library', 'STATE.md'), 'utf8'))
+  && /## FIVE NAMED MINDS/.test(fs.readFileSync(path.join(docsDir, 'library', 'STATE.md'), 'utf8'))
+  && !/## FIVE NAMED MINDS[\s\S]*Celeste —/.test(fs.readFileSync(path.join(docsDir, 'library', 'STATE.md'), 'utf8')));
+assert('v5.79.41 chair-test: harness has v5_79_41 box pointer suite',
+  /harness\.available\.v5_79_41/.test(harness7941)
+  && /testPickerPresent/.test(harness7941)
+  && /testCallingNamesEndpoint/.test(harness7941)
+  && /testCorsHonest/.test(harness7941)
+  && /testNoSecondWizard/.test(harness7941));
+assert('v5.79.41 marker present',
+  app7941.includes('v5.79.41-chat-box-pointer'));
+
+// Triple-bump v5.79.41
+assert('v5.79.41 triple-bump: app.html FL_VERSION = 5.79.41',
+  /FL_VERSION\s*=\s*'5\.79\.41'/.test(app7941));
+assert('v5.79.41 triple-bump: docs/sw.js CACHE_NAME = freelattice-v5.79.41',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.41'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
+assert('v5.79.41 triple-bump: root sw.js CACHE_NAME = freelattice-v5.79.41',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.41'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
+assert('v5.79.41 version.json: version field = 5.79.41',
+  /"version"\s*:\s*"5\.79\.41"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
 
 // RESULTS
 // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat is cleaner after the one-room pass, but Kirk still could not point at a local or LAN box (Tabgent, Ollama on another machine, any LAN inference). CORS remains the known disaster. This is the Chat second pass he asked for.

## Audit (not a rebuild)

These already existed. They were not recreated:

- `getOllamaBaseUrl` / `fl_ollamaHost` / hidden `#ollamaHostInput` (buried in `#chatConfigSection`, `display:none`)
- `ollamaFetch` + `/ollama` proxy (proxy still targeted *this* machine)
- Custom endpoint (`fl_customEndpoint` + Settings `<details>` + provider modal)
- CORS wizard (`FLWizard` / `showCorsHelp` / `scanForLocalAI` elapsed>200 heuristic)
- InferenceRouter `#flProviderStatus` footer
- `FLChatActivity` as the single writer for `#statusText`

## What shipped (smallest honest layer)

One **Box** field on Chat's path (`#flBoxPointerInput` / `FLBoxPointer`):

- Kirk types `localhost:11434` or `192.168.x.x:11434` (or a `/v1` URL). No `confirm()`.
- Writes the existing `fl_ollamaHost` store; syncs the hidden host field; reuses `updateOllamaProviderUrl`.
- Probes with the existing elapsed>200 CORS heuristic (not a second wizard).
- **Calling** names the endpoint: `Calling llama3.2 at 192.168.1.50:11434…`
- **CORS** is honest on the bar: `Error — CORS blocked 192.168.1.50:11434`. Tap the picker status to open the *existing* FLWizard / `showCorsHelp`.
- `ollamaFetch` skips the same-origin proxy for non-loopback hosts so a LAN pointer does not hit the wrong box. Chat's Ollama send path now uses `ollamaFetch`.
- InferenceRouter footer speaks the host (and `CORS blocked` when that is the health).

## Constraints honored

- Never delete, only layer. Quiet Room unmeasured (`quiet-room.js` untouched).
- `FLChatActivity` stays the single writer. No companion personality phrases on the live status bar.
- Trainer not rebuilt. Alpha not ported. No `confirm()` on local work.
- FIVE NAMED MINDS stay five. Celeste remains a NOW note, not a sixth name.
- Triple-bump: `FL_VERSION`, `flCurrentVersion`, both `sw.js` `CACHE_NAME`, `docs/version.json`.
- Smoke +19 (section 186). Green: **3494/3494**.

## Chair-test

1. Open Chat. Find **Box** next to the model pill.
2. Type a local or LAN address. Blur or Enter. Expect Connected / CORS blocked / Not reached.
3. Send a message. Expect the bar to name *Calling [model] at [address]…*, or *Error — CORS blocked [address]*.
4. Optional console: `chairTest.available.v5_79_41.runAll()`.

Credit: Kirk asked for the Chat second pass. Celeste oversaw. Hypha watches for cuts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0630cd5d-abc9-47df-8be9-5675d16e7274?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0630cd5d-abc9-47df-8be9-5675d16e7274&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

