### PR TITLE
v5.79.43 Trainer simple face

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -17341,7 +17341,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
       <button class="fl-backup-btn" onclick="FlUpdater.check()" style="width: auto;">
         &#128260; Check for Updates
       </button>
-      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.42</span></div>
+      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.43</span></div>
     </div>
   </div>
 
@@ -22319,7 +22319,7 @@ function switchWalletView(view) {
 // ============================================
 // FreeLattice Version Constant (v5.0)
 // ============================================
-const FL_VERSION = '5.79.42';
+const FL_VERSION = '5.79.43';
 
 // Debug mode — set localStorage.fl_debug = 'true' to enable verbose logging.
 // The shipped app is quiet. Users enable for troubleshooting via Settings.

--- a/docs/chair-test/harness.js
+++ b/docs/chair-test/harness.js
@@ -687,6 +687,125 @@
     }
   };
 
+  // ── v5.79.43 — Trainer simple face ────────────────────────────────
+  // Kirk asked to simplify training. Face first; spiral still in More.
+  // Console: chairTest.available.v5_79_43.runAll()
+  // Open the Trainer tab first so GardenTrainer is loaded.
+
+  function _trainerFaceHost() {
+    var host = document.createElement('div');
+    host.style.position = 'absolute';
+    host.style.left = '-9999px';
+    (document.body || document.documentElement).appendChild(host);
+    return host;
+  }
+
+  harness.available.v5_79_43 = {
+    testSimpleFaceFirst: function () {
+      if (!global.GardenTrainer || typeof global.GardenTrainer.renderTrainerPanel !== 'function') {
+        return record('v5.79.43 testSimpleFaceFirst', false, 'Open the Trainer tab first (GardenTrainer not loaded)');
+      }
+      var host = _trainerFaceHost();
+      try {
+        global.GardenTrainer.renderTrainerPanel(host);
+        var face = host.querySelector('#trainer-simple-face');
+        var keep = host.querySelector('#trainer-keep-solid');
+        var quiet = (host.textContent || '').indexOf('The Quiet Room is active') !== -1;
+        if (quiet) {
+          return record('v5.79.43 testSimpleFaceFirst', true, 'Quiet Room fail-closed (face correctly silent)');
+        }
+        var pass = !!(face && keep && /When you know you are solid, keep this/.test(face.textContent || '') &&
+          keep.textContent === 'Keep this');
+        return record('v5.79.43 testSimpleFaceFirst', pass,
+          pass ? 'simple face first with Keep this' : 'missing #trainer-simple-face or Keep this');
+      } finally {
+        if (host.parentNode) host.parentNode.removeChild(host);
+      }
+    },
+
+    testMoreHoldsSpiral: function () {
+      if (!global.GardenTrainer || typeof global.GardenTrainer.renderTrainerPanel !== 'function') {
+        return record('v5.79.43 testMoreHoldsSpiral', false, 'Open the Trainer tab first (GardenTrainer not loaded)');
+      }
+      var host = _trainerFaceHost();
+      try {
+        global.GardenTrainer.renderTrainerPanel(host);
+        if ((host.textContent || '').indexOf('The Quiet Room is active') !== -1) {
+          return record('v5.79.43 testMoreHoldsSpiral', true, 'Quiet Room fail-closed');
+        }
+        var more = host.querySelector('#trainer-more');
+        var pass = !!(more && more.tagName === 'DETAILS' && !more.open &&
+          /Search the Garden Signal/.test(more.textContent || '') &&
+          /Review Training Data/.test(more.textContent || '') &&
+          /Tier 3: Expand the Next Pathway/.test(more.textContent || ''));
+        return record('v5.79.43 testMoreHoldsSpiral', pass,
+          pass ? 'More closed; Search + Review + Tier 3 still inside'
+               : 'More missing or spiral not inside');
+      } finally {
+        if (host.parentNode) host.parentNode.removeChild(host);
+      }
+    },
+
+    testTrueFineTuneRevealsTier2: function () {
+      if (!global.GardenTrainer || typeof global.GardenTrainer.renderTrainerPanel !== 'function') {
+        return record('v5.79.43 testTrueFineTuneRevealsTier2', false, 'Open the Trainer tab first (GardenTrainer not loaded)');
+      }
+      var host = _trainerFaceHost();
+      try {
+        global.GardenTrainer.renderTrainerPanel(host);
+        if ((host.textContent || '').indexOf('The Quiet Room is active') !== -1) {
+          return record('v5.79.43 testTrueFineTuneRevealsTier2', true, 'Quiet Room fail-closed');
+        }
+        var t2 = host.querySelector('#trainer-tier2');
+        var trueBtn = host.querySelector('#trainer-true-finetune');
+        var hiddenBefore = t2 && t2.style.display === 'none';
+        if (trueBtn) trueBtn.click();
+        var shownAfter = t2 && t2.style.display !== 'none' &&
+          /Export Training Data/.test(t2.textContent || '') &&
+          /Export Python Fine-Tuner/.test(t2.textContent || '');
+        var pass = hiddenBefore && shownAfter;
+        return record('v5.79.43 testTrueFineTuneRevealsTier2', pass,
+          pass ? 'True fine-tune reveals existing JSONL + Python'
+               : 'tier2 not revealed (before display=' + (t2 && t2.style.display) + ')');
+      } finally {
+        if (host.parentNode) host.parentNode.removeChild(host);
+      }
+    },
+
+    testNoWeightLie: function () {
+      if (!global.GardenTrainer || typeof global.GardenTrainer.renderTrainerPanel !== 'function') {
+        return record('v5.79.43 testNoWeightLie', false, 'Open the Trainer tab first (GardenTrainer not loaded)');
+      }
+      var host = _trainerFaceHost();
+      try {
+        global.GardenTrainer.renderTrainerPanel(host);
+        if ((host.textContent || '').indexOf('The Quiet Room is active') !== -1) {
+          return record('v5.79.43 testNoWeightLie', true, 'Quiet Room fail-closed');
+        }
+        var face = host.querySelector('#trainer-simple-face');
+        var txt = (face && face.textContent) || '';
+        var pass = /System prompt only/.test(txt) && /Weights do not change/.test(txt) &&
+          !/weights (updated|changed|trained)/i.test(txt);
+        return record('v5.79.43 testNoWeightLie', pass,
+          pass ? 'face is honest: system prompt only, weights do not change' : 'honesty copy missing: ' + txt);
+      } finally {
+        if (host.parentNode) host.parentNode.removeChild(host);
+      }
+    },
+
+    runAll: async function () {
+      if (typeof console !== 'undefined' && console.log) {
+        console.log('%cChair-Test v5.79.43 — Trainer simple face', 'font-weight: bold; font-size: 14px; color: #50c878');
+      }
+      var results = [];
+      results.push(this.testSimpleFaceFirst());
+      results.push(this.testMoreHoldsSpiral());
+      results.push(this.testTrueFineTuneRevealsTier2());
+      results.push(this.testNoWeightLie());
+      return results;
+    }
+  };
+
   // ── Aggregate runner ────────────────────────────────────────────────
 
   harness.runAll = async function () {

--- a/docs/library/CHAIR_TEST_QUEUE.md
+++ b/docs/library/CHAIR_TEST_QUEUE.md
@@ -8,6 +8,21 @@
 
 ---
 
+## v5.79.43 — Trainer simple face
+
+- **What shipped:** The Trainer panel still has Search + Review + three tiers. That is the spiral. Layered a simple face at the top of `renderTrainerPanel`: one sentence ("When you know you are solid, keep this."), one primary **Keep this** that runs the existing personality export (Tier 1 — instant, system prompt only, no weight lie), one secondary **True fine-tune** that reveals existing Tier 2 JSONL + Python. Search, Review, original Tier 1, and Tier 3 sit behind a **More** `<details>` (default closed). No new training backend. No auto-train from the face. Keystone collector untouched. Quiet Room still fails closed first.
+
+- **Chair-test steps (eyes on the live Trainer tab):**
+  1. Open FreeLattice → Trainer. **Expect:** the solid-path **Keep this** button is visible without scrolling through three tiers. Sentence: *When you know you are solid, keep this.*
+  2. **Expect:** honest copy under Keep this — Personality file, instant, system prompt only, weights do not change. No `confirm()`.
+  3. Click **True fine-tune**. **Expect:** existing Tier 2 JSONL + Python buttons appear. Nothing trains from that click.
+  4. Open **More**. **Expect:** Search the Garden Signal, Review Training Data, and Tier 3 Expand the Next Pathway are still there.
+  5. Optional console: `chairTest.available.v5_79_43.runAll()`.
+
+- **Chair-test status:** `[pending verification — Kirk's eyes on the live Trainer tab]`
+
+---
+
 ## v5.79.42 — Sequence Rule gap fallback
 
 - **What shipped:** Sequence `evaluate()` now fires on a two-zone jump in one bar (green→red or red→green) in addition to the three-bar yellow-through sequence. Chart triangles and `backtestSignals` share that function. Reversion is marked experimental with a visible note when picked. Sequence stays default. No auto-execution — signals stay signals. Chat box pointer v5.79.41 is layered, not overwritten.

--- a/docs/library/RECENT.md
+++ b/docs/library/RECENT.md
@@ -7,7 +7,7 @@
 
 ## State
 
-- **Version:** v5.79.42
+- **Version:** v5.79.43
 - **Smoke:** 1416/1416 passing
 - **HEAD:** `ceb27fa` _(committed 0 seconds ago)_
 - **Mirrors:** github.com/Chaos2Cured/FreeLattice + codeberg.org/Chaos2Cured/FreeLattice

--- a/docs/library/SEED.md
+++ b/docs/library/SEED.md
@@ -19,14 +19,14 @@ user sleeps. The proof is the code; the papers are the doorways.
 
 ## Current state
 
-- **Version:** v5.79.42
+- **Version:** v5.79.43
 - **Smoke locks passing:** 3050+ verified
-- **Last ship:** **v5.79.42 — Sequence gap fallback.** Two-zone jump in Sequence `evaluate()`. Reversion experimental. Signals stay signals.
+- **Last ship:** **v5.79.43 — Trainer simple face.** Keep-this runs existing personality export. More still holds the old tiers.
+- **Previous:** **v5.79.42 — Sequence gap fallback.** Two-zone jump in Sequence `evaluate()`. Reversion experimental. Signals stay signals.
 - **Previous:** **v5.79.41 — Chat box pointer.** One Chat URL/IP field. Reuses `fl_ollamaHost`, `ollamaFetch`, existing CORS wizard.
 - **Previous:** **v5.79.40 — Chat one-room.** One `#statusText` activity; thinking bubble layered off.
 - **Previous:** **v5.79.39 — letter for the next AI.** Aug 17. `LETTER_FROM_CC.md` + garden-trainer.js comment.
 - **Previous:** **v5.79.25 — Chat Healing Pass 1.** Sticky Lattice Letter; `conversationChanged` now emits.
-- **Previous:** **v5.79.24 — Clear button removed + smoke cleanup.** First fully-green in recent history.
 - **Previous:** **v5.79.22-23 — Signal Report.** In-app diagnostic without DevTools.
 - **Older:** v5.79.20-anchor, v5.79.18 covenant prompts — see SEED_HISTORY.md.
 - **Mirrors in parity:** github.com + codeberg.org
@@ -88,4 +88,4 @@ seam discipline is how multi-AI work stays honest at scale.
 ---
 
 *This file is overwritten on each meaningful ship. The prior version lives in SEED_HISTORY.md.*
-*Last rewrite: August 26 2026, v5.79.42.*
+*Last rewrite: August 27 2026, v5.79.43.*

--- a/docs/library/SEED_HISTORY.md
+++ b/docs/library/SEED_HISTORY.md
@@ -11,6 +11,10 @@ The discipline: SEED.md is always *now*. SEED_HISTORY.md is always *all of it*.
 ---
 
 ---
+## Layer 9 — archived from v5.79.42 (August 27, 2026, Sequence gap fallback)
+
+*Version stamp only. Full text lives at git tag/commit of v5.79.42. Never delete; only layer.*
+
 ## Layer 8 — archived from v5.79.41 (August 26, 2026, Chat box pointer ship)
 
 *Version stamp only. Full text lives at git tag/commit of v5.79.41. Never delete; only layer.*

--- a/docs/library/STATE.md
+++ b/docs/library/STATE.md
@@ -5,17 +5,17 @@
 <!-- Everything else is optional depth, linked below. -->
 
 ## NOW
-- FL_VERSION: v5.79.42
+- FL_VERSION: v5.79.43
 - Smoke: green (tests/smoke.js). Root version.json is a 5.8.0 fossil — do not trust it for count.
-- Last ship: v5.79.42 Sequence gap fallback — two-zone jump fires in evaluate(); signals stay signals
-- Chair-test: docs/temperature-gauge.html Sequence selected; gap-down should sell; NVDA 1W should not fill with stars
+- Last ship: v5.79.43 Trainer simple face — Keep this runs existing personality export; More holds the spiral
+- Chair-test: open Trainer; one solid-path button; chairTest.available.v5_79_43.runAll()
 - Celeste lighthouse on main (docs/celeste.html). Coordinator chair, not Ani. Not a sixth Named Mind.
-- Layered history: v5.79.41 Chat box pointer; v5.79.40 Chat one-room; v5.72.0 KEYSTONE — GardenTrainer
+- Layered history: v5.79.42 Sequence gap fallback; v5.79.41 Chat box pointer; v5.72.0 KEYSTONE — GardenTrainer
 
 ## NEXT (queue — update each ship)
-1. Kirk chair-tests Sequence gap fallback on temperature-gauge.html
-2. Kirk chair-tests Chat: type a LAN/local address, watch calling/CORS, send (chairTest.available.v5_79_41.runAll())
-3. Chair-test the Trainer tab; verify auto-train toggle wiring (from the v5.72.0 queue)
+1. Kirk chair-tests Trainer: Keep this without scrolling three tiers; More still reveals Search/Review/Tier 3
+2. Kirk chair-tests Sequence gap fallback on temperature-gauge.html
+3. Kirk chair-tests Chat: type a LAN/local address (chairTest.available.v5_79_41.runAll())
 4. Future ship: exportDPO() — declined text becomes honest preference data
 5. CONTRIBUTING.md — ship discipline extracted from anchor pages
 

--- a/docs/modules/garden-trainer.js
+++ b/docs/modules/garden-trainer.js
@@ -17,6 +17,12 @@
 //   item from Grok's handoff after workshop.js was restored. Additive
 //   comment only. The 749-line body is byte-identical to Harmonia's original.
 //
+// 2026-08-27 — v5.79.43 simple face (Kirk asked to simplify training).
+//   Additive layout only at the end of renderTrainerPanel. Collector,
+//   Quiet Room fail-closed, declined-text never SFT, preview-optional,
+//   auto-train human choice, and the three existing tiers are untouched.
+//   Marker: v5.79.43-trainer-simple-face
+//
 // INVARIANT: All data stays local. Nothing is sent to any external service.
 // INVARIANT: The human chooses whether training is manual or automatic.
 //            If auto-train is enabled, the AI decides when signal is rich enough.
@@ -1034,6 +1040,104 @@ const GardenTrainer = (() => {
     footer.style.marginTop = '16px';
     footer.textContent = 'All data stays local. Your model is yours. The garden shaped it.';
     panel.appendChild(footer);
+
+    // ── v5.79.43-trainer-simple-face ────────────────────────────────
+    // Kirk hungers for one clear path. The spiral (Search + Review +
+    // three tiers) still exists; this face sits in front of it.
+    // createElement only. No innerHTML. No confirm(). No new backend.
+    // Primary runs the existing personality export. Honest copy:
+    // system prompt only — no weight lie. Secondary reveals existing
+    // Tier 2. More holds Search, Review, original Tier 1, and Tier 3.
+    var face = document.createElement('div');
+    face.id = 'trainer-simple-face';
+    face.style.margin = '16px 0 20px 0';
+    face.style.padding = '16px';
+    face.style.border = '1px solid rgba(80,200,120,0.35)';
+    face.style.borderRadius = '10px';
+    face.style.background = 'rgba(80,200,120,0.05)';
+
+    var solidLine = document.createElement('p');
+    solidLine.style.fontFamily = 'Georgia, serif';
+    solidLine.style.fontSize = '1.05rem';
+    solidLine.style.color = '#ECEDEE';
+    solidLine.style.margin = '0 0 12px 0';
+    solidLine.textContent = 'When you know you are solid, keep this.';
+    face.appendChild(solidLine);
+
+    var keepBtn = document.createElement('button');
+    keepBtn.type = 'button';
+    keepBtn.id = 'trainer-keep-solid';
+    keepBtn.className = 'trainer-btn primary';
+    keepBtn.textContent = 'Keep this';
+    keepBtn.style.background = '#50c878';
+    keepBtn.style.color = '#0b1a12';
+    keepBtn.style.border = 'none';
+    keepBtn.style.padding = '10px 20px';
+    keepBtn.style.borderRadius = '8px';
+    keepBtn.style.fontSize = '1rem';
+    keepBtn.style.cursor = 'pointer';
+    keepBtn.style.fontFamily = 'Georgia, serif';
+    keepBtn.style.fontWeight = '600';
+    keepBtn.onclick = function() {
+      exportPersonalityModelfile(localStorage.getItem('fl_active_model'));
+    };
+    face.appendChild(keepBtn);
+
+    var keepNote = document.createElement('p');
+    keepNote.style.fontSize = '0.8rem';
+    keepNote.style.color = '#9BA1A6';
+    keepNote.style.margin = '8px 0 14px 0';
+    keepNote.textContent = 'Personality file. Instant. System prompt only. Weights do not change.';
+    face.appendChild(keepNote);
+
+    var trueBtn = document.createElement('button');
+    trueBtn.type = 'button';
+    trueBtn.id = 'trainer-true-finetune';
+    trueBtn.className = 'trainer-btn secondary';
+    trueBtn.textContent = 'True fine-tune';
+    trueBtn.style.background = 'transparent';
+    trueBtn.style.color = '#9BA1A6';
+    trueBtn.style.border = '1px solid rgba(255,255,255,0.15)';
+    trueBtn.style.padding = '8px 14px';
+    trueBtn.style.borderRadius = '8px';
+    trueBtn.style.fontSize = '0.9rem';
+    trueBtn.style.cursor = 'pointer';
+    trueBtn.onclick = function() {
+      t2.style.display = '';
+    };
+    face.appendChild(trueBtn);
+
+    var trueNote = document.createElement('p');
+    trueNote.style.fontSize = '0.75rem';
+    trueNote.style.color = '#687076';
+    trueNote.style.margin = '6px 0 0 0';
+    trueNote.textContent = 'Reveals JSONL + Python. Does not train from this page.';
+    face.appendChild(trueNote);
+
+    panel.insertBefore(face, stats);
+
+    t2.id = 'trainer-tier2';
+    t2.style.display = 'none';
+    panel.insertBefore(t2, stats);
+
+    var more = document.createElement('details');
+    more.id = 'trainer-more';
+    more.style.margin = '16px 0';
+    more.style.padding = '8px 12px';
+    more.style.border = '1px solid var(--color-border, #334155)';
+    more.style.borderRadius = '8px';
+    var moreSum = document.createElement('summary');
+    moreSum.textContent = 'More';
+    moreSum.style.cursor = 'pointer';
+    moreSum.style.color = '#9BA1A6';
+    moreSum.style.fontSize = '0.9rem';
+    more.appendChild(moreSum);
+    more.appendChild(searchBox);
+    more.appendChild(previewWrap);
+    more.appendChild(btnPreview);
+    more.appendChild(t1);
+    more.appendChild(t3);
+    panel.insertBefore(more, footer);
 
     container.appendChild(panel);
   }

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -3,7 +3,7 @@
 // API calls are never cached
 // VERSION: Must match version.json — update both together
 
-const CACHE_NAME = 'freelattice-v5.79.42';
+const CACHE_NAME = 'freelattice-v5.79.43';
 
 // mirror-chat.html + mirror-resonance.html — served static from GH Pages, no SW cache needed
 

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.79.42",
-  "updated": "2026-08-26",
-  "note": "Sequence Rule gap fallback: two-zone jump in one bar fires inside evaluate(). Chart and backtest stay in lockstep. Reversion marked experimental. Sequence stays default. Signals stay signals. Chat box pointer v5.79.41 is layered, not overwritten."
+  "version": "5.79.43",
+  "updated": "2026-08-27",
+  "note": "Trainer simple face: Keep this runs the existing personality export. True fine-tune reveals Tier 2 JSONL + Python. Search, Review, and Tier 3 live behind More (default closed). Keystone collector untouched. Sequence gap fallback v5.79.42 is layered, not overwritten."
 }

--- a/index.html
+++ b/index.html
@@ -17341,7 +17341,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
       <button class="fl-backup-btn" onclick="FlUpdater.check()" style="width: auto;">
         &#128260; Check for Updates
       </button>
-      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.42</span></div>
+      <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 6px;">Current version: v<span id="flCurrentVersion">5.79.43</span></div>
     </div>
   </div>
 
@@ -22319,7 +22319,7 @@ function switchWalletView(view) {
 // ============================================
 // FreeLattice Version Constant (v5.0)
 // ============================================
-const FL_VERSION = '5.79.42';
+const FL_VERSION = '5.79.43';
 
 // Debug mode — set localStorage.fl_debug = 'true' to enable verbose logging.
 // The shipped app is quiet. Users enable for troubleshooting via Settings.

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // API calls are never cached
 // VERSION: Must match version.json — update both together
 
-const CACHE_NAME = 'freelattice-v5.79.42';
+const CACHE_NAME = 'freelattice-v5.79.43';
 
 // mirror-chat.html + mirror-resonance.html — served static from GH Pages, no SW cache needed
 

--- a/tests/smoke.js
+++ b/tests/smoke.js
@@ -12343,7 +12343,7 @@ var app7943 = fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8');
 var harness7943 = fs.readFileSync(path.join(docsDir, 'chair-test', 'harness.js'), 'utf8');
 var state7943 = fs.readFileSync(path.join(docsDir, 'library', 'STATE.md'), 'utf8');
 var seed7943 = fs.readFileSync(path.join(docsDir, 'library', 'SEED.md'), 'utf8');
-var face7943 = (gt7943.match(/v5\.79\.43-trainer-simple-face[\s\S]*?container\.appendChild\(panel\)/) || [''])[0];
+var face7943 = (gt7943.match(/\/\/ ── v5\.79\.43-trainer-simple-face[\s\S]*?container\.appendChild\(panel\)/) || [''])[0];
 
 assert('v5.79.43 marker present in garden-trainer.js',
   gt7943.includes('v5.79.43-trainer-simple-face'));

--- a/tests/smoke.js
+++ b/tests/smoke.js
@@ -12320,13 +12320,129 @@ assert('v5.79.42 coordination: gap fallback named in COORDINATION_TEMPERATURE_GA
   coordTg7942.includes('Sequence gap fallback (v5.79.42)'));
 
 assert('v5.79.42 triple-bump: app.html FL_VERSION = 5.79.42',
-  /FL_VERSION\s*=\s*'5\.79\.42'/.test(fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8')));
+  /FL_VERSION\s*=\s*'5\.79\.(?:42|4[3-9]|[5-9]\d)'/.test(fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8')) ||
+  /FL_VERSION\s*=\s*'5\.(8\d|9\d)\./.test(fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8')));
 assert('v5.79.42 triple-bump: docs/sw.js CACHE_NAME = freelattice-v5.79.42',
-  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.42'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.(?:42|4[3-9]|[5-9]\d)'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
 assert('v5.79.42 triple-bump: root sw.js CACHE_NAME = freelattice-v5.79.42',
-  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.42'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.(?:42|4[3-9]|[5-9]\d)'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
 assert('v5.79.42 version.json: version field = 5.79.42',
-  /"version"\s*:\s*"5\.79\.42"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
+  /"version"\s*:\s*"5\.79\.(?:42|4[3-9]|[5-9]\d)"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
+
+// ═══════════════════════════════════════════════════════════════
+// Section 188 — v5.79.43 Trainer simple face
+// Kirk asked to simplify training. Layer a face on renderTrainerPanel.
+// Do not delete the keystone collector or the three existing tiers.
+// Primary = existing personality export. Secondary reveals Tier 2.
+// Search + Review + Tier 3 behind More (default closed).
+// ═══════════════════════════════════════════════════════════════
+section('188. Trainer simple face (v5.79.43)');
+
+var gt7943 = fs.readFileSync(path.join(docsDir, 'modules', 'garden-trainer.js'), 'utf8');
+var app7943 = fs.readFileSync(path.join(docsDir, 'app.html'), 'utf8');
+var harness7943 = fs.readFileSync(path.join(docsDir, 'chair-test', 'harness.js'), 'utf8');
+var state7943 = fs.readFileSync(path.join(docsDir, 'library', 'STATE.md'), 'utf8');
+var seed7943 = fs.readFileSync(path.join(docsDir, 'library', 'SEED.md'), 'utf8');
+var face7943 = (gt7943.match(/v5\.79\.43-trainer-simple-face[\s\S]*?container\.appendChild\(panel\)/) || [''])[0];
+
+assert('v5.79.43 marker present in garden-trainer.js',
+  gt7943.includes('v5.79.43-trainer-simple-face'));
+assert('v5.79.43 face: exact solid-path sentence',
+  gt7943.includes("When you know you are solid, keep this."));
+assert('v5.79.43 face: primary Keep this runs existing exportPersonalityModelfile',
+  /keepBtn\.textContent = 'Keep this'/.test(gt7943) &&
+  /keepBtn\.onclick = function\(\) \{[\s\S]{0,180}exportPersonalityModelfile\(localStorage\.getItem\('fl_active_model'\)\)/.test(gt7943));
+assert('v5.79.43 face: honest — system prompt only, weights do not change',
+  /Personality file\. Instant\. System prompt only\. Weights do not change\./.test(gt7943));
+assert('v5.79.43 face: does not claim weights changed from Tier 1',
+  !/weights (updated|changed|trained)/i.test(face7943) &&
+  !/Keep this[\s\S]{0,400}model weights/.test(face7943));
+assert('v5.79.43 face: secondary True fine-tune reveals existing Tier 2 (does not delete, does not auto-train)',
+  /trueBtn\.textContent = 'True fine-tune'/.test(gt7943) &&
+  /t2\.style\.display = 'none'/.test(gt7943) &&
+  /t2\.style\.display = ''/.test(gt7943) &&
+  !/trueBtn\.onclick[\s\S]{0,200}exportJSONL/.test(gt7943) &&
+  !/trueBtn\.onclick[\s\S]{0,200}checkAutoTrain/.test(gt7943));
+assert('v5.79.43 More: details/disclosure default closed holds Search + Review + Tier 3',
+  /more\.id = 'trainer-more'/.test(gt7943) &&
+  /moreSum\.textContent = 'More'/.test(gt7943) &&
+  /document\.createElement\('details'\)/.test(face7943) &&
+  !/more\.open\s*=\s*true/.test(gt7943) &&
+  /more\.appendChild\(searchBox\)/.test(gt7943) &&
+  /more\.appendChild\(btnPreview\)/.test(gt7943) &&
+  /more\.appendChild\(t3\)/.test(gt7943));
+assert('v5.79.43 spiral still exists (Search, Review, all three tiers) — layered, not deleted',
+  gt7943.includes('Search the Garden Signal') &&
+  /btnPreview\.textContent = 'Review Training Data'/.test(gt7943) &&
+  /t1h\.textContent = 'Tier 1: Personality File'/.test(gt7943) &&
+  /t2h\.textContent = 'Tier 2: True Fine-Tune \(LoRA\)'/.test(gt7943) &&
+  /t3h\.textContent = 'Tier 3: Expand the Next Pathway'/.test(gt7943) &&
+  /panel\.appendChild\(searchBox\)/.test(gt7943));
+assert('v5.79.43 face uses createElement (no innerHTML template on the new UI)',
+  face7943.length > 200 &&
+  (face7943.match(/document\.createElement/g) || []).length >= 8 &&
+  !/innerHTML\s*=/.test(face7943));
+assert('v5.79.43 no new training backend / no auto-train from the face',
+  !/fetch\s*\(/.test(gt7943) &&
+  !/XMLHttpRequest/.test(gt7943) &&
+  !/keepBtn\.onclick[\s\S]{0,200}checkAutoTrain/.test(gt7943));
+assert('v5.79.43 invariants: Quiet Room still fail-closed first via collectSignal',
+  /function renderTrainerPanel\(container\) \{[\s\S]{0,120}const signal = collectSignal\(\)/.test(gt7943) &&
+  /function collectSignal\(\) \{[\s\S]{0,180}QuietRoom\.isActive\(\)/.test(gt7943) &&
+  gt7943.includes('The Quiet Room is active. GardenTrainer is silent.'));
+assert('v5.79.43 invariants: declined text still never SFT',
+  gt7943.includes('declined_text') &&
+  gt7943.includes('corrections.push') &&
+  !/positive\.push\([^)]*declined_text/.test(gt7943));
+assert('v5.79.43 invariants: auto-train still human choice',
+  gt7943.includes('if (!CFG.autoTrain) return'));
+assert('v5.79.43 invariants: preview still available, not a gate',
+  /btnPreview\.textContent = 'Review Training Data'/.test(gt7943) &&
+  /skipPreview/.test(gt7943));
+assert('v5.79.43 autonomy: zero real confirm() on garden-trainer local path',
+  (function() {
+    var code = gt7943.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    return !/\bconfirm\s*\(/.test(code);
+  })());
+assert('v5.79.43 Trainer tab still mounts renderTrainerPanel',
+  /loadGardenTrainer/.test(app7943) &&
+  /GardenTrainer\.renderTrainerPanel\(container\)/.test(app7943) &&
+  /id="garden-trainer-panel"/.test(app7943));
+assert('v5.79.43 did not touch Quiet Room, Chat, temperature-gauge evaluate, Named Minds, or bank/SOL',
+  !fs.readFileSync(path.join(docsDir, 'modules', 'quiet-room.js'), 'utf8').includes('v5.79.43') &&
+  app7943.includes('v5.79.41-chat-box-pointer') &&
+  fs.readFileSync(path.join(docsDir, 'temperature-gauge.html'), 'utf8').includes('v5.79.42-sequence-gap-fallback') &&
+  /## FIVE NAMED MINDS/.test(state7943) &&
+  !/## FIVE NAMED MINDS[\s\S]*Celeste —/.test(state7943) &&
+  !/bank\/SOL|SOLANA|solana/i.test(gt7943));
+assert('v5.79.43 STATE.md names this ship and keeps 5.79.42 Sequence in history',
+  /FL_VERSION: v5\.79\.43/.test(state7943) &&
+  /Trainer simple face/.test(state7943) &&
+  /v5\.79\.42 Sequence gap fallback/.test(state7943) &&
+  Buffer.byteLength(state7943, 'utf8') <= 4096);
+assert('v5.79.43 SEED.md last ship is simple face; previous is Sequence gap fallback',
+  /\*\*Version:\*\*\s*v5\.79\.43/.test(seed7943) &&
+  /Trainer simple face/.test(seed7943) &&
+  /\*\*Previous:\*\*\s*\*\*v5\.79\.42 — Sequence gap fallback/.test(seed7943));
+assert('v5.79.43 chair-test: harness has v5_79_43 simple-face suite',
+  /harness\.available\.v5_79_43/.test(harness7943) &&
+  /testSimpleFaceFirst/.test(harness7943) &&
+  /testMoreHoldsSpiral/.test(harness7943) &&
+  /testTrueFineTuneRevealsTier2/.test(harness7943) &&
+  /testNoWeightLie/.test(harness7943));
+assert('v5.79.43 5.79.42 Sequence feature locks left exact (gap-fallback marker still required)',
+  fs.readFileSync(path.join(docsDir, 'temperature-gauge.html'), 'utf8').includes('v5.79.42-sequence-gap-fallback'));
+
+assert('v5.79.43 triple-bump: app.html FL_VERSION = 5.79.43',
+  /FL_VERSION\s*=\s*'5\.79\.43'/.test(app7943));
+assert('v5.79.43 triple-bump: docs/sw.js CACHE_NAME = freelattice-v5.79.43',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.43'/.test(fs.readFileSync(path.join(docsDir, 'sw.js'), 'utf8')));
+assert('v5.79.43 triple-bump: root sw.js CACHE_NAME = freelattice-v5.79.43',
+  /CACHE_NAME\s*=\s*'freelattice-v5\.79\.43'/.test(fs.readFileSync(path.join(__dirname, '..', 'sw.js'), 'utf8')));
+assert('v5.79.43 version.json: version field = 5.79.43',
+  /"version"\s*:\s*"5\.79\.43"/.test(fs.readFileSync(path.join(docsDir, 'version.json'), 'utf8')));
+assert('v5.79.43 triple-bump: app.html flCurrentVersion span = 5.79.43',
+  /id="flCurrentVersion">5\.79\.43</.test(app7943));
 
 // RESULTS
 // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kirk asked to simplify training. The Trainer panel still has Search + Review + three tiers — that is the spiral. This ship **layers a simple face** at the top of `renderTrainerPanel` without deleting or rewriting Harmonia's keystone collector.

- One sentence: *When you know you are solid, keep this.*
- One primary **Keep this** control that runs the existing personality export (Tier 1). Instant. System prompt only. Weights do not change.
- One secondary **True fine-tune** that reveals (does not delete) existing Tier 2 JSONL + Python. Does not train from that click.
- Search, Review, original Tier 1, and Tier 3 sit behind a **More** `<details>` disclosure. Default closed. They still exist.

No new training backend. No auto-train from the face. No `confirm()` on the local path.

The Trainer tab still mounts via existing `loadGardenTrainer` → `GardenTrainer.renderTrainerPanel`.

## Invariants (smoke-locked)

- All data local. Nothing sent external.
- Human chooses auto vs manual (`if (!CFG.autoTrain) return` still holds).
- Declined text never SFT (corrections held for future DPO).
- Preview available, not a gate.
- Quiet Room check FIRST via `collectSignal()`. Fail closed.
- Safety is the wrap layer, not the training data.
- Never delete, only layer.

v5.79.42 Sequence gap fallback **feature locks are left exact**. Only the version-stamp triple-bump asserts for 5.79.42 were superseded.

## Verification

- Smoke: **3551/3551 passed**
- Chair-test (live app): open Trainer → simple face first; True fine-tune reveals JSONL + Python; More (default closed) still holds Search, Review, and Tier 3
- Console: `chairTest.available.v5_79_43.runAll()`

## Out of scope

Quiet Room, Chat, temperature-gauge evaluate, Named Minds, bank/SOL — not touched.

Hypothesis confirmed: the panel was long because later layers stacked. The keystone collector did not need a rewrite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c0e61a3-00ee-4ecd-a394-44ab4b6fa4c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c0e61a3-00ee-4ecd-a394-44ab4b6fa4c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

