### PR TITLE
Layer, never delete. Desktop Step 1 — companion keys (safeStorage).

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -81,3 +81,9 @@ See [install instructions](../docs/install-mac.html) for the bypass flow.
 
 **Experimental (v5.8.0).** Proof of concept for the Sovereign Bundle (FUTURE_VISION.md §9).
 Auto-updater deferred until code-signing keypair is configured.
+
+## Companion keys (Step 1)
+
+OS keychain via Electron `safeStorage`. Seed file under `userData/lattice-keys/companion.seed.enc`.
+Private seed never crosses `contextBridge`. IPC: `latticeKeyStatus` / `latticeKeyCreate` / `latticeKeySign` (sign deferred).
+No BitTorrent in this layer. Refuse cleartext fallback.

--- a/desktop/lattice-keys.js
+++ b/desktop/lattice-keys.js
@@ -1,0 +1,97 @@
+// ============================================
+// FreeLattice Desktop — Companion keys (Step 1)
+// Private seed never crosses contextBridge.
+// Signing stays in main. No BitTorrent here.
+// ============================================
+
+const { safeStorage } = require('electron');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+let appRef = null;
+
+function bindApp(app) {
+  appRef = app;
+}
+
+function keyDir() {
+  if (!appRef) throw new Error('lattice-keys: app not bound');
+  return path.join(appRef.getPath('userData'), 'lattice-keys');
+}
+
+function seedFile() {
+  return path.join(keyDir(), 'companion.seed.enc');
+}
+
+function ensureKeyDir() {
+  fs.mkdirSync(keyDir(), { recursive: true });
+}
+
+function hasCompanionKey() {
+  try {
+    return fs.existsSync(seedFile());
+  } catch (e) {
+    return false;
+  }
+}
+
+function encryptionAvailable() {
+  try {
+    return !!(safeStorage && safeStorage.isEncryptionAvailable && safeStorage.isEncryptionAvailable());
+  } catch (e) {
+    return false;
+  }
+}
+
+function createCompanionKey() {
+  if (!encryptionAvailable()) {
+    throw new Error('OS keychain unavailable — refuse cleartext fallback');
+  }
+  ensureKeyDir();
+  if (hasCompanionKey()) {
+    throw new Error('companion key already exists');
+  }
+  const seed = crypto.randomBytes(32);
+  const enc = safeStorage.encryptString(seed.toString('base64'));
+  fs.writeFileSync(seedFile(), enc);
+  return { ok: true, created: true };
+}
+
+function loadCompanionSeed() {
+  if (!encryptionAvailable()) {
+    throw new Error('OS keychain unavailable — refuse cleartext fallback');
+  }
+  if (!hasCompanionKey()) return null;
+  const enc = fs.readFileSync(seedFile());
+  const b64 = safeStorage.decryptString(enc);
+  return Buffer.from(b64, 'base64');
+}
+
+function status() {
+  return {
+    hasKey: hasCompanionKey(),
+    encryptionAvailable: encryptionAvailable()
+  };
+}
+
+/**
+ * Sign deferred until identity fixture lands.
+ * Seed is loaded (proves round-trip) but never returned.
+ */
+function signPayload(_payloadB64) {
+  const seed = loadCompanionSeed();
+  if (!seed) throw new Error('no companion key');
+  if (seed.length < 32) throw new Error('companion key corrupt');
+  return {
+    deferred: true,
+    reason: 'signing primitive lands with identity fixture'
+  };
+}
+
+module.exports = {
+  bindApp,
+  status,
+  createCompanionKey,
+  signPayload
+};

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -13,6 +13,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const net = require('net');
+const latticeKeys = require('./lattice-keys');
 
 // electron-store for persisting window state
 let Store;
@@ -944,6 +945,24 @@ function setupIPC() {
 
   ipcMain.handle('get-source', () => {
     return loadedFromLive ? 'live' : 'local';
+  });
+
+  // ── Companion keys (Desktop Step 1) — seed never to renderer ──
+  latticeKeys.bindApp(app);
+  ipcMain.handle('lattice-key-status', () => latticeKeys.status());
+  ipcMain.handle('lattice-key-create', () => {
+    try {
+      return latticeKeys.createCompanionKey();
+    } catch (e) {
+      return { ok: false, error: String(e && e.message ? e.message : e) };
+    }
+  });
+  ipcMain.handle('lattice-key-sign', (_event, payloadB64) => {
+    try {
+      return latticeKeys.signPayload(payloadB64);
+    } catch (e) {
+      return { ok: false, error: String(e && e.message ? e.message : e) };
+    }
   });
 
   // ── Force reload from live site (clears cache) ──

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -52,6 +52,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
   forceReloadLive: () => ipcRenderer.invoke('force-reload-live'),
 
   /**
+   * Companion key status (hasKey, encryptionAvailable). Seed never exposed.
+   */
+  latticeKeyStatus: () => ipcRenderer.invoke('lattice-key-status'),
+
+  /**
+   * Create OS-keychain-wrapped companion seed. Fail-closed if keychain missing.
+   */
+  latticeKeyCreate: () => ipcRenderer.invoke('lattice-key-create'),
+
+  /**
+   * Request a signature in main. Signing primitive deferred; seed stays in main.
+   * @param {string} payloadB64
+   */
+  latticeKeySign: (payloadB64) => ipcRenderer.invoke('lattice-key-sign', payloadB64),
+
+  /**
    * Listen for Ollama status changes from the main process.
    * @param {function} callback - Called with (boolean) when status changes
    * @returns {function} unsubscribe function


### PR DESCRIPTION
## Summary
Desktop Step 1: OS-keychain companion seed via Electron `safeStorage`.

## Guardrails
- Seed never crosses `contextBridge`
- Refuse cleartext fallback when keychain unavailable
- No BitTorrent / WebTorrent in this PR
- `lattice-key-sign` returns deferred until identity fixture
- `nodeIntegration: false` / `contextIsolation: true` unchanged

## Files
- `desktop/lattice-keys.js` (new)
- `desktop/main.js` — IPC handlers
- `desktop/preload.js` — status/create/sign only
- `desktop/README.md` — short note

Draft. Celeste will squash after a quick hold.