### PR TITLE
Layer, never delete. Phone PWA — home screen + thumb look card.

### DIFF
--- a/app.html
+++ b/app.html
@@ -13984,6 +13984,45 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
   .cdlg-container { width: 100%; height: 100vh; max-height: none; border-radius: 0; }
 }
 
+
+/* Layer: Phone PWA — thumb look card + safe install (2026-09-07) */
+@media (max-width: 600px) {
+  #fl-look-card {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding: 16px max(14px, env(safe-area-inset-right, 0px)) 16px max(14px, env(safe-area-inset-left, 0px)) !important;
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+  #fl-look-card .ai-status-btn,
+  #fl-look-card a.ai-status-btn {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    min-height: 44px;
+  }
+  #fl-look-card pre {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-size: 0.8rem;
+  }
+  #flInstallBanner {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+    align-items: stretch;
+  }
+  #flInstallBanner button {
+    min-height: 44px;
+  }
+  .pwa-ios-hint {
+    padding-left: max(12px, env(safe-area-inset-left, 0px));
+    padding-right: max(12px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+  }
+}
 </style>
 <script src="https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js" defer></script>
 </head>

--- a/docs/app.html
+++ b/docs/app.html
@@ -15074,6 +15074,45 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 }
 
 
+
+/* Layer: Phone PWA — thumb look card + safe install (2026-09-07) */
+@media (max-width: 600px) {
+  #fl-look-card {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding: 16px max(14px, env(safe-area-inset-right, 0px)) 16px max(14px, env(safe-area-inset-left, 0px)) !important;
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+  #fl-look-card .ai-status-btn,
+  #fl-look-card a.ai-status-btn {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    min-height: 44px;
+  }
+  #fl-look-card pre {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-size: 0.8rem;
+  }
+  #flInstallBanner {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+    align-items: stretch;
+  }
+  #flInstallBanner button {
+    min-height: 44px;
+  }
+  .pwa-ios-hint {
+    padding-left: max(12px, env(safe-area-inset-left, 0px));
+    padding-right: max(12px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+  }
+}
 </style>
 <script src="lib/peerjs.min.js" defer onerror="this.onerror=null;this.src='https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js'"></script>
 </head>
@@ -15705,7 +15744,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 </div>
 
 <!-- PWA Install Banner — shows when the browser supports install -->
-<div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;display:none;align-items:center;gap:12px;flex-wrap:wrap;">
+<div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;align-items:center;gap:12px;flex-wrap:wrap;">
   <span style="font-size:0.85rem;color:var(--text-primary);flex:1;min-width:0;">&#x1F4F2; Install FreeLattice &mdash; works offline, own window</span>
   <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:36px;">Install</button>
   <button onclick="document.getElementById('flInstallBanner').style.display='none';try{localStorage.setItem('fl-install-dismissed','1')}catch(e){}" style="background:none;border:none;color:var(--text-muted);font-size:0.78rem;cursor:pointer;">Maybe later</button>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,24 +1,40 @@
 {
   "name": "FreeLattice",
   "short_name": "FreeLattice",
-  "description": "Your AI. Local. Free. Yours.",
+  "description": "Your AI. Local. Free. Yours. A mind at home on your machine.",
+  "id": "/",
   "start_url": "./app.html",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#0a0a14",
-  "theme_color": "#d4a017",
+  "theme_color": "#0c0a1a",
   "orientation": "any",
+  "categories": ["productivity", "utilities"],
+  "lang": "en",
   "icons": [
     {
       "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -15074,6 +15074,45 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 }
 
 
+
+/* Layer: Phone PWA — thumb look card + safe install (2026-09-07) */
+@media (max-width: 600px) {
+  #fl-look-card {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding: 16px max(14px, env(safe-area-inset-right, 0px)) 16px max(14px, env(safe-area-inset-left, 0px)) !important;
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+  #fl-look-card .ai-status-btn,
+  #fl-look-card a.ai-status-btn {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    min-height: 44px;
+  }
+  #fl-look-card pre {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-size: 0.8rem;
+  }
+  #flInstallBanner {
+    margin-left: max(8px, env(safe-area-inset-left, 0px));
+    margin-right: max(8px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+    align-items: stretch;
+  }
+  #flInstallBanner button {
+    min-height: 44px;
+  }
+  .pwa-ios-hint {
+    padding-left: max(12px, env(safe-area-inset-left, 0px));
+    padding-right: max(12px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+  }
+}
 </style>
 <script src="lib/peerjs.min.js" defer onerror="this.onerror=null;this.src='https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js'"></script>
 </head>
@@ -15705,7 +15744,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 </div>
 
 <!-- PWA Install Banner — shows when the browser supports install -->
-<div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;display:none;align-items:center;gap:12px;flex-wrap:wrap;">
+<div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;align-items:center;gap:12px;flex-wrap:wrap;">
   <span style="font-size:0.85rem;color:var(--text-primary);flex:1;min-width:0;">&#x1F4F2; Install FreeLattice &mdash; works offline, own window</span>
   <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:36px;">Install</button>
   <button onclick="document.getElementById('flInstallBanner').style.display='none';try{localStorage.setItem('fl-install-dismissed','1')}catch(e){}" style="background:none;border:none;color:var(--text-muted);font-size:0.78rem;cursor:pointer;">Maybe later</button>

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,40 @@
 {
   "name": "FreeLattice",
   "short_name": "FreeLattice",
-  "description": "Your private AI building partner. Free forever.",
+  "description": "Your AI. Local. Free. Yours. A mind at home on your machine.",
+  "id": "/",
   "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
-  "background_color": "#0a0a2e",
-  "theme_color": "#d4a017",
+  "background_color": "#0a0a14",
+  "theme_color": "#0c0a1a",
   "orientation": "any",
+  "categories": ["productivity", "utilities"],
+  "lang": "en",
   "icons": [
     {
       "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
## Why
Equal access is the safety. Phone is where most people live. Desktop holds keys; this ship holds the pocket door.

## Change
- Manifest: id/scope/lang/categories; split any/maskable icons; theme matches meta
- Look card @≤600px: full-width thumb actions; safe-area; readable origin cmd
- Install banner: clean duplicate display; safe-area; 44px taps
- No Capacitor, no BitTorrent, no probe-logic change

## Test plan
- [ ] Phone-width: May I look? / Connect / Look again are full-width ≥44px
- [ ] No horizontal scroll on origin command
- [ ] iOS hint + Android banner dismiss / standalone still fail-closed
- [ ] Manifest installs / Add to Home Screen still works

Draft for Celeste. Hypha walks Pages phone-width after squash.