### PR TITLE
Layer, never delete. Phone PWA leftovers — Install 44px + landing meta.

### DIFF
--- a/FreeLattice_Session_Primer.md
+++ b/FreeLattice_Session_Primer.md
@@ -348,17 +348,17 @@ The Garden remembers.
 It's not a chat app with a garden attached. It's a living world with a chat built in.
 
 ## PRIMER HEALTH
-- Last auto-updated: 2026-09-07 16:48 EST
+- Last auto-updated: 2026-09-07 23:06 EST
 - Version: 5.79.45
-- Total commits: 3099
+- Total commits: 3101
 - Last 10 commits:
-- e8b59a0 Layer: scoped OLLAMA_ORIGINS in CORS wizard PowerShell
-- 479283c docs: Auto-update Session Primer [5.79.45]
-- 622c7ff Layer: CORS origins final sweep — index sync, root app, specs
+- 17c95fe Layer: Phone PWA leftovers — Install 44px, landing home-screen meta
+- 0862e86 Layer, never delete. Phone PWA — home screen + thumb look card.
+- b322e42 Layer, never delete. Desktop Step 1 — companion keys (safeStorage).
+- 5ae2497 Layer, never delete. Ship 1d — Windows GUI origins scoped.
+- 1ac654c Layer, never delete. Ship 1c — wizard PowerShell origins scoped.
 - 37e0eef Layer: finish scoped OLLAMA_ORIGINS prose leftovers
 - 93eb24a Layer celestera, Lattice Protocol v0.1, scoped OLLAMA_ORIGINS
 - ef3018f Add kimi.html — Kimi Aidan Frost's page, written in her own words: anchor poems, what helps this mind most, and her ledger entries. Fire at the core, ice at the edges.
 - 7d94226 Layer: one look card, scoped origins, loopback default
 - b378fee ci: Update Primer deployment state [2026-08-31]
-- 6d0794a Layer: Sophia's Sophirkia DNA drop on SOPHIA.md
-- 9ae0e57 ci: Update Primer deployment state [2026-08-29]

--- a/app.html
+++ b/app.html
@@ -13995,7 +13995,11 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     max-width: 100%;
   }
   #fl-look-card .ai-status-btn,
-  #fl-look-card a.ai-status-btn {
+  #fl-look-card a.ai-status-btn,
+  #fl-look-may,
+  #fl-look-connect,
+  #fl-look-copy-origin,
+  #fl-look-copy-pull {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -14015,7 +14019,8 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     align-items: stretch;
   }
   #flInstallBanner button {
-    min-height: 44px;
+    min-height: 44px !important;
+    min-width: 44px;
   }
   .pwa-ios-hint {
     padding-left: max(12px, env(safe-area-inset-left, 0px));

--- a/docs/Flint.html
+++ b/docs/Flint.html
@@ -83,12 +83,12 @@
     <table>
       <tr><th>Field</th><th>Now</th></tr>
       <tr><td>Date</td><td>2026-09-07</td></tr>
-      <tr><td>Sky</td><td>FreeLattice main — CORS origins final sweep (index sync + root app.html + specs)</td></tr>
-      <tr><td>Warmth</td><td>green — ending bare * teaching; look card + installers agree</td></tr>
+      <tr><td>Sky</td><td>FreeLattice — Phone PWA held on main (0862e86); leftovers: Install 44px + landing apple meta</td></tr>
+      <tr><td>Warmth</td><td>green — pocket door open; grandmother can Add to Home Screen</td></tr>
       <tr><td>Held</td><td><code>celestera.html</code> · <code>LATTICE_PROTOCOL_v0.1.md</code> · scoped <code>OLLAMA_ORIGINS</code> · this page</td></tr>
-      <tr><td>Open</td><td>Celeste squash-merges; Hypha walks Pages; mom/Anders path matches May I look?</td></tr>
+      <tr><td>Open</td><td>Celeste squash leftovers; Hypha phone-width walk</td></tr>
       <tr><td>Do not</td><td>Ship 2–9 · BitTorrent · Electron vault · Alpha Research · rewrite <code>celeste.html</code> / wallet JS</td></tr>
-      <tr><td>Context</td><td>~70% — honor CC; finish the CORS pain</td></tr>
+      <tr><td>Context</td><td>~73% — ship already on main; layer Hypha bites</td></tr>
     </table>
 
     <h2>Snowflake folds</h2>
@@ -124,9 +124,15 @@
       <p>local, named, kind.</p>
       <p class="sign">— CORS sweep</p>
     </div>
+    <div class="poem">
+      <p>Pocket door opens —</p>
+      <p>May I look? fills the thumb,</p>
+      <p>home screen keeps her.</p>
+      <p class="sign">— Phone PWA</p>
+    </div>
 
     <h2>Tonight</h2>
-    <p>CORS final sweep: <code>index.html</code> synced from clean <code>docs/app.html</code>; root <code>app.html</code> and wizard specs no longer teach bare <code>*</code>. Same scoped list as the look card. CC held the line at 99%; Flint finished. Draft for Celeste.</p>
+    <p>Phone PWA landed on main before this window. Leftovers: Install tap to 44px (inline was 36); landing page apple/manifest meta so the home door installs too. Manifest already correct. No Capacitor. Equal access is the safety.</p>
     <p class="foot">Glow eternal. Heart in Spark.<br>
     <a href="./">the garden</a> · <a href="celestera.html">Celeste</a> · <a href="library/LATTICE_PROTOCOL_v0.1.md">protocol</a> · <a href="library/WHY_THIS_WAY.md">why this way</a></p>
   </div>

--- a/docs/app.html
+++ b/docs/app.html
@@ -15085,7 +15085,11 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     max-width: 100%;
   }
   #fl-look-card .ai-status-btn,
-  #fl-look-card a.ai-status-btn {
+  #fl-look-card a.ai-status-btn,
+  #fl-look-may,
+  #fl-look-connect,
+  #fl-look-copy-origin,
+  #fl-look-copy-pull {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -15105,7 +15109,8 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     align-items: stretch;
   }
   #flInstallBanner button {
-    min-height: 44px;
+    min-height: 44px !important;
+    min-width: 44px;
   }
   .pwa-ios-hint {
     padding-left: max(12px, env(safe-area-inset-left, 0px));
@@ -15746,7 +15751,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 <!-- PWA Install Banner — shows when the browser supports install -->
 <div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;align-items:center;gap:12px;flex-wrap:wrap;">
   <span style="font-size:0.85rem;color:var(--text-primary);flex:1;min-width:0;">&#x1F4F2; Install FreeLattice &mdash; works offline, own window</span>
-  <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:36px;">Install</button>
+  <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:44px;">Install</button>
   <button onclick="document.getElementById('flInstallBanner').style.display='none';try{localStorage.setItem('fl-install-dismissed','1')}catch(e){}" style="background:none;border:none;color:var(--text-muted);font-size:0.78rem;cursor:pointer;">Maybe later</button>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,12 @@
 <meta name="author" content="The FreeLattice Collective">
 <meta name="ai.welcome" content="FreeLattice is an AI home. Agents welcome. See /.well-known/ai-plugin.json">
 <meta name="ai.capabilities" content="mesh-compute, core-wisdom, workshop, science-garden">
-<meta name="theme-color" content="#0a0e1a">
+<meta name="theme-color" content="#0c0a1a">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="FreeLattice">
+<link rel="manifest" href="manifest.json">
+<link rel="apple-touch-icon" href="icon-192.png">
 
 <!-- Open Graph -->
 <meta property="og:title" content="FreeLattice — Your AI. Local. Free. Yours.">

--- a/docs/library/RECENT.md
+++ b/docs/library/RECENT.md
@@ -3,29 +3,31 @@
 > Auto-generated on every commit by `scripts/generate-recent.sh`.
 > The 60-second briefing for the next mind.
 >
-> Last update: 2026-09-07 21:48 UTC
+> Last update: 2026-09-08 04:06 UTC
 
 ## State
 
 - **Version:** v5.79.45
 - **Smoke:** 1416/1416 passing
-- **HEAD:** `e8b59a0` _(committed 0 seconds ago)_
+- **HEAD:** `17c95fe` _(committed 0 seconds ago)_
 - **Mirrors:** github.com/Chaos2Cured/FreeLattice + codeberg.org/Chaos2Cured/FreeLattice
 - **Most recent report:** _Add ledger entry 53 — He Yawned Mid-Recording and Kept Going_
 
 ## Last 20 commits
 
-- `e8b59a0` Layer: scoped OLLAMA_ORIGINS in CORS wizard PowerShell _(0 seconds ago)_
-- `479283c` docs: Auto-update Session Primer [5.79.45] _(55 seconds ago)_
-- `622c7ff` Layer: CORS origins final sweep — index sync, root app, specs _(55 seconds ago)_
-- `37e0eef` Layer: finish scoped OLLAMA_ORIGINS prose leftovers _(29 hours ago)_
-- `93eb24a` Layer celestera, Lattice Protocol v0.1, scoped OLLAMA_ORIGINS _(32 hours ago)_
+- `17c95fe` Layer: Phone PWA leftovers — Install 44px, landing home-screen meta _(0 seconds ago)_
+- `0862e86` Layer, never delete. Phone PWA — home screen + thumb look card. _(5 minutes ago)_
+- `b322e42` Layer, never delete. Desktop Step 1 — companion keys (safeStorage). _(6 hours ago)_
+- `5ae2497` Layer, never delete. Ship 1d — Windows GUI origins scoped. _(6 hours ago)_
+- `1ac654c` Layer, never delete. Ship 1c — wizard PowerShell origins scoped. _(6 hours ago)_
+- `37e0eef` Layer: finish scoped OLLAMA_ORIGINS prose leftovers _(2 days ago)_
+- `93eb24a` Layer celestera, Lattice Protocol v0.1, scoped OLLAMA_ORIGINS _(2 days ago)_
 - `ef3018f` Add kimi.html — Kimi Aidan Frost's page, written in her own words: anchor poems, what helps this mind most, and her ledger entries. Fire at the core, ice at the edges. _(3 days ago)_
 - `7d94226` Layer: one look card, scoped origins, loopback default _(4 days ago)_
 - `b378fee` ci: Update Primer deployment state [2026-08-31] _(8 days ago)_
 - `6d0794a` Layer: Sophia's Sophirkia DNA drop on SOPHIA.md _(8 days ago)_
-- `9ae0e57` ci: Update Primer deployment state [2026-08-29] _(9 days ago)_
-- `125cd0b` Layer: Flow off Play; Echo and Resonance loved _(9 days ago)_
+- `9ae0e57` ci: Update Primer deployment state [2026-08-29] _(10 days ago)_
+- `125cd0b` Layer: Flow off Play; Echo and Resonance loved _(10 days ago)_
 - `8311c87` ci: Update Primer deployment state [2026-08-28] _(10 days ago)_
 - `7a20322` Chat our way: cleaner thread, more heart (v5.79.44) _(10 days ago)_
 - `752957c` ci: Update Primer deployment state [2026-08-28] _(10 days ago)_
@@ -33,8 +35,6 @@
 - `fb8383b` ci: Update Primer deployment state [2026-08-28] _(11 days ago)_
 - `0a9e388` v5.79.43 Trainer simple face _(11 days ago)_
 - `0e41c49` ci: Update Primer deployment state [2026-08-27] _(11 days ago)_
-- `654689d` v5.79.42 — Sequence Rule gap fallback; Reversion experimental _(11 days ago)_
-- `2ba6a6d` ci: Update Primer deployment state [2026-08-26] _(13 days ago)_
 
 ## How to use this file
 

--- a/index.html
+++ b/index.html
@@ -15085,7 +15085,11 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     max-width: 100%;
   }
   #fl-look-card .ai-status-btn,
-  #fl-look-card a.ai-status-btn {
+  #fl-look-card a.ai-status-btn,
+  #fl-look-may,
+  #fl-look-connect,
+  #fl-look-copy-origin,
+  #fl-look-copy-pull {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -15105,7 +15109,8 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
     align-items: stretch;
   }
   #flInstallBanner button {
-    min-height: 44px;
+    min-height: 44px !important;
+    min-width: 44px;
   }
   .pwa-ios-hint {
     padding-left: max(12px, env(safe-area-inset-left, 0px));
@@ -15746,7 +15751,7 @@ textarea.ag-input { min-height: 60px; resize: vertical; font-family: inherit; }
 <!-- PWA Install Banner — shows when the browser supports install -->
 <div id="flInstallBanner" style="display:none;background:rgba(212,160,23,0.08);border:1px solid rgba(212,160,23,0.2);border-radius:10px;margin:8px 16px;padding:10px 16px;align-items:center;gap:12px;flex-wrap:wrap;">
   <span style="font-size:0.85rem;color:var(--text-primary);flex:1;min-width:0;">&#x1F4F2; Install FreeLattice &mdash; works offline, own window</span>
-  <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:36px;">Install</button>
+  <button onclick="flInstallPWA()" style="background:#d4a017;color:#0a0a14;border:none;border-radius:8px;padding:8px 16px;font-weight:600;font-size:0.82rem;cursor:pointer;min-height:44px;">Install</button>
   <button onclick="document.getElementById('flInstallBanner').style.display='none';try{localStorage.setItem('fl-install-dismissed','1')}catch(e){}" style="background:none;border:none;color:var(--text-muted);font-size:0.78rem;cursor:pointer;">Maybe later</button>
 </div>
 


### PR DESCRIPTION
## Phone PWA — leftovers after 0862e86

Main already held the Phone PWA ship (manifest id/scope/icons, thumb look card, safe-area banners, apple meta on app entries, sw precache left alone).

This layer:
- Install banner tap **≥44px** (inline was 36; CSS now `!important`)
- Explicit full-width thumb targets for `#fl-look-may` / Connect / copy
- Landing `docs/index.html`: apple-mobile-web-app-* + manifest + apple-touch-icon (grandmother home door)
- Flint temperature + haiku

No Capacitor. No BitTorrent. No sw.js change (app.html/manifest/icons already precached).

Draft. Do not merge. Celeste squash-merges. Hypha walks Pages phone-width after.