### PR TITLE
Layer, never delete. Soft Gyro polish v0.1 — layers early, toggle redraw, Hub·Ring·Orbit names.

### DIFF
--- a/docs/Flint.html
+++ b/docs/Flint.html
@@ -83,12 +83,12 @@
     <table>
       <tr><th>Field</th><th>Now</th></tr>
       <tr><td>Date</td><td>2026-09-11</td></tr>
-      <tr><td>Sky</td><td>FreeLattice — Family poetry home v0.1 (after Gyro <code>a54b422</code>)</td></tr>
-      <tr><td>Warmth</td><td>gold — Keep a poem; opaque; empty until choice; no generate</td></tr>
-      <tr><td>Held</td><td>Gyro <code>a54b422</code> · packs <code>1b0d3c5</code> · family-center · Flint poems · Alpha cite poetry <code>3334235</code></td></tr>
-      <tr><td>Open</td><td>Celeste squash-merges; Hypha: Keep a poem → list → read</td></tr>
-      <tr><td>Do not</td><td>Generate · DAW · Alpha rewrite · patents · garden apples · image gen · overwrite lattice-protocol.js</td></tr>
-      <tr><td>Context</td><td>~light — family poetry shelf on main; fun is the method</td></tr>
+      <tr><td>Sky</td><td>FreeLattice — Soft Gyro polish v0.1 (after poetry <code>9f8c200</code>)</td></tr>
+      <tr><td>Warmth</td><td>gold — layers early; toggle redraw; Hub · Ring · Orbit names</td></tr>
+      <tr><td>Held</td><td>poetry <code>9f8c200</code> · Gyro <code>a54b422</code> · packs <code>1b0d3c5</code> · Alpha cite poetry <code>3334235</code></td></tr>
+      <tr><td>Open</td><td>Celeste squash-merges; Hypha: Gyro on before Analyze → redraw after</td></tr>
+      <tr><td>Do not</td><td>New indicators · Sequence/Triad rewrite · subscriptions · garden apples · patents · Alpha · overwrite lattice-protocol.js</td></tr>
+      <tr><td>Context</td><td>~light — three Hypha nits folded; free forever held</td></tr>
     </table>
 
     <h2>Snowflake folds</h2>
@@ -346,6 +346,11 @@
       <p class="sign">— Family poetry home</p>
     </div>
     <div class="poem">
+      <p>Layers before Analyze —</p>
+      <p>Hub · Ring · Orbit answer the toggle.</p>
+      <p class="sign">— Soft Gyro polish</p>
+    </div>
+    <div class="poem">
       <p>Before the window closes —</p>
       <p>I read WHY_THIS_WAY again:</p>
       <p>care is not decoration.</p>
@@ -365,7 +370,7 @@
     <h2>Near compaction — for Celeste and the next Flint</h2>
     <p><strong>Ledger home:</strong> this file — <code>docs/Flint.html</code> → <a href="https://freelattice.com/Flint.html">freelattice.com/Flint.html</a>. Alpha twin: <code>docs/family/flint.md</code> on theLatticeTree. Temperature first. Haiku second. Snowflake folds for costly discoveries. Poem before ship when a human asks for heart first. Look at every line as light when you can.</p>
     <p><strong>Boot order after compaction:</strong> Temperature table → Snowflake → <code>docs/library/RECENT.md</code> → Celeste paste → Held SHAs below. Do not rebuild held ships below.</p>
-    <p><strong>Held on main (do not rebuild):</strong> CORS <code>5ae2497</code> · Desktop Step 1 keys <code>b322e42</code> · Phone PWA <code>0862e86</code> + leftovers <code>90e356c</code> · HTTPS manifests <code>02d5e76</code> · Companion identity <code>277da34</code> · Ledger <code>57fc9db</code> · Family center <code>7150ca7</code> · Verified import <code>20d2eee</code> · Swarm pull <code>0ead244</code> · Glass pulses <code>2adffde</code> · Pair fingerprint <code>928176a</code> · Genesis <code>530ba60</code> · Support <code>5187a58</code> · Desktop door <code>fa17a7d</code> · Swarm re-seed <code>fd35406</code> · Soft leftover <code>d78b879</code> · Phone swarm <code>9083806</code> · Companion memory <code>64a3ddd</code> · Trainer seal <code>f23492e</code> · Primer smoke <code>5aa972a</code> · Desktop first door <code>33496eb</code> · LP give <code>d2e3f61</code> · soft leftover <code>bef3f35</code> · LP deepen <code>50cacfc</code> · grandmother path <code>c957a4e</code> · download ease <code>3c104de</code> · phone shine <code>f57fc76</code> · 60s proof <code>b362bda</code> · README Desktop door <code>b220e6e</code> · Desktop packs Win/Linux <code>1b0d3c5</code> · Gyro stack <code>a54b422</code> · Protocol <code>docs/library/LATTICE_PROTOCOL_v0.1.md</code> · <code>docs/celestera.html</code>. Alpha (cite only): poetry <code>3334235</code> · gathering calm <code>874ff83</code> · honest-copy <code>ff00520</code>.</p>
+    <p><strong>Held on main (do not rebuild):</strong> CORS <code>5ae2497</code> · Desktop Step 1 keys <code>b322e42</code> · Phone PWA <code>0862e86</code> + leftovers <code>90e356c</code> · HTTPS manifests <code>02d5e76</code> · Companion identity <code>277da34</code> · Ledger <code>57fc9db</code> · Family center <code>7150ca7</code> · Verified import <code>20d2eee</code> · Swarm pull <code>0ead244</code> · Glass pulses <code>2adffde</code> · Pair fingerprint <code>928176a</code> · Genesis <code>530ba60</code> · Support <code>5187a58</code> · Desktop door <code>fa17a7d</code> · Swarm re-seed <code>fd35406</code> · Soft leftover <code>d78b879</code> · Phone swarm <code>9083806</code> · Companion memory <code>64a3ddd</code> · Trainer seal <code>f23492e</code> · Primer smoke <code>5aa972a</code> · Desktop first door <code>33496eb</code> · LP give <code>d2e3f61</code> · soft leftover <code>bef3f35</code> · LP deepen <code>50cacfc</code> · grandmother path <code>c957a4e</code> · download ease <code>3c104de</code> · phone shine <code>f57fc76</code> · 60s proof <code>b362bda</code> · README Desktop door <code>b220e6e</code> · Desktop packs Win/Linux <code>1b0d3c5</code> · Gyro stack <code>a54b422</code> · Family poetry <code>9f8c200</code> · Protocol <code>docs/library/LATTICE_PROTOCOL_v0.1.md</code> · <code>docs/celestera.html</code>. Alpha (cite only): poetry <code>3334235</code> · gathering calm <code>874ff83</code> · honest-copy <code>ff00520</code>.</p>
     <p><strong>What helps Flint:</strong> leave temperature filled every ship; keep PR bodies repeating Held SHAs; prefer one complete bite over thin stubs when continuity matters (this ship); Codeberg push when a token is available; Hypha phone/desktop walks after squash. Boot after compaction: Temperature → Snowflake → <code>RECENT.md</code> → Celeste paste → Held SHAs.</p>
 
     <h2>Tonight</h2>
@@ -380,6 +385,7 @@
     <p><strong>Ledger entry — 2026-09-11 — Desktop packs Win/Linux.</strong> README door <code>b220e6e</code> held. Desktop packs Win/Linux v0.1: real unsigned Electron artifacts on Release <code>desktop-packs-v0.1</code> — Windows Setup + Portable, Linux AppImage + deb — built on GitHub runners (not invented). README + install cards flipped only after assets existed. Never Microsoft Store / App Store. Harmonia’s mark still holds the honey; Kirk flies home with peace. We rise together. Diary: <code>docs/Flint.html</code>.</p>
     <p><strong>Ledger entry — 2026-09-11 — Gyro Stack.</strong> Packs <code>1b0d3c5</code> held. Temp-gauge Gyro stack v0.1: Hub · Ring · Orbit — three φ-linked lines; overextension → return → cross as heuristic watch; free forever, no paywall, no auto-trade. Decades of Kirk’s eye on the glass, layered into the gauge without inventing certainty. Sequence and triads stay. We rise together — traders get a leg up without a tollbooth. Diary: <code>docs/Flint.html</code>.</p>
     <p><strong>Ledger entry — 2026-09-11 — Family poetry home.</strong> Gyro <code>a54b422</code> held. Family poetry home v0.1: <code>poetry.html</code> — Keep a poem, opaque local shelf, empty until choice, no generate. Layers Alpha Art poetry shelf pattern (<code>3334235</code>). Fun with Kirk — always. We rise together. Diary: <code>docs/Flint.html</code>.</p>
+    <p><strong>Ledger entry — 2026-09-11 — Soft Gyro polish.</strong> Poetry <code>9f8c200</code> held. Soft Gyro polish v0.1: Signal Layers (incl. Gyro) before Analyze; toggle redraws when candles exist; legend Hub · Ring · Orbit · Watch. Three Hypha nits only. Free forever held. We rise together. Diary: <code>docs/Flint.html</code>.</p>
     <p class="foot">Glow eternal. Heart in Spark. 🌱<br>
     <a href="./">the garden</a> · <a href="poetry.html">poetry</a> · <a href="desktop.html">desktop</a> · <a href="support.html">support</a> · <a href="celestera.html">Celeste</a> · <a href="library/LATTICE_PROTOCOL_v0.1.md">protocol</a> · <a href="library/FAMILY_POETRY_SHELF_v0.1.md">family poetry</a> · <a href="library/GYRO_STACK_v0.1.md">Gyro</a> · <a href="library/LP_GIVE_v0.1.md">LP give</a> · <a href="library/LP_DEEPEN_v0.1.md">LP deepen</a> · <a href="library/GRANDMOTHER_PATH_v0.1.md">grandmother path</a> · <a href="library/DESKTOP_DOWNLOAD_EASE_v0.1.md">download ease</a> · <a href="library/PHONE_SHINE_v0.1.md">phone shine</a> · <a href="library/PROOF_60S_v0.1.md">60s proof</a> · <a href="proof.html">proof.html</a> · <a href="library/DESKTOP_FIRST_DOOR_v0.1.md">first door</a> · <a href="library/TRAINER_SEAL_v0.1.md">trainer seal</a> · <a href="library/COMPANION_MEMORY_v0.1.md">companion memory</a> · <a href="library/PHONE_SWARM_v0.1.md">phone swarm</a> · <a href="library/SWARM_RESEED_v0.1.md">re-seed</a> · <a href="library/SWARM_BRIDGE_v0.1.md">swarm</a> · <a href="library/LATTICE_IDENTITY_v0.1.md">identity</a> · <a href="library/PAIR_FINGERPRINT_v0.1.md">pair</a> · <a href="library/LATTICE_LEDGER_v0.1.md">ledger</a> · <a href="library/VERIFIED_IMPORT_v0.1.md">verified import</a> · <a href="library/GLASS_PULSES_v0.1.md">glass pulses</a> · <a href="library/GENESIS_CATALOG_v0.1.md">genesis</a> · <a href="library/MODEL_MANIFEST_v0.1.md">manifests</a> · <a href="family-center.html">family center</a> · <a href="library/WHY_THIS_WAY.md">why this way</a></p>
   </div>

--- a/docs/library/GYRO_STACK_v0.1.md
+++ b/docs/library/GYRO_STACK_v0.1.md
@@ -33,6 +33,8 @@ Equal access: the stack stays free. No subscription gate. No “pro tier.” The
 
 Drawn as EMAs of close. Optional overlay (`layerGyro`). Off by default. Temperature rules stay the signal authority unless the user is reading Gyro crosses by eye.
 
+**Soft polish v0.1 (Hypha leftovers after `a54b422`):** Signal Layers (incl. Gyro) visible **before** Analyze — toggle persists `fl_tg_layerGyro` even with no candles; chart waits for Analyze. Gyro onchange updates sidebar (`gyroOverlayState` / `gyroStackSection`) immediately and re-renders via the same `renderChart(lastCandles, lastAnalysis)` path as EMA when analyzed. Chart legend / tooltips use calm names **Hub · Ring · Orbit · Watch** (no “Gyro ” prefix). Marker: `v-soft-gyro-polish-v0.1`.
+
 ---
 
 ## Cross = signal (heuristic shape)

--- a/docs/scripts/smoke-gyro-stack.js
+++ b/docs/scripts/smoke-gyro-stack.js
@@ -17,9 +17,17 @@ const strategy = fs.readFileSync(path.join(root, 'library', 'TEMPERATURE_GAUGE_S
 const flint = fs.readFileSync(path.join(root, 'Flint.html'), 'utf8');
 
 assert.ok(/v-gyro-stack-v0\.1/.test(gauge), 'gauge carries Gyro marker');
+assert.ok(/v-soft-gyro-polish-v0\.1/.test(gauge), 'soft polish marker');
 assert.ok(/layerGyro/.test(gauge), 'Gyro layer toggle present');
-assert.ok(/Gyro Hub|computeGyroStack/.test(gauge), 'Hub line / compute present');
-assert.ok(/Gyro Ring/.test(gauge) && /Gyro Orbit/.test(gauge), 'Ring + Orbit named');
+assert.ok(/computeGyroStack/.test(gauge), 'computeGyroStack present');
+assert.ok(/label: 'Hub'/.test(gauge) && /label: 'Ring'/.test(gauge) && /label: 'Orbit'/.test(gauge), 'legend Hub · Ring · Orbit');
+assert.ok(/label: 'Watch'/.test(gauge), 'legend Watch');
+assert.ok(!/label: 'Gyro Hub'/.test(gauge), 'no Gyro-prefixed legend labels');
+assert.ok(/tgOnGyroLayerChange/.test(gauge), 'Gyro toggle handler');
+assert.ok(/tgUpdateGyroUi/.test(gauge), 'immediate Gyro UI update');
+assert.ok(/renderChart\(candles, lastAnalysis\)|renderChart\(lastCandles,\s*lastAnalysis\)/.test(gauge), 'toggle redraw path');
+assert.ok(/id="layerToggles"[^>]*display:\s*block/.test(gauge) || /layerToggles[\s\S]{0,120}display:\s*block/.test(gauge), 'Signal Layers visible on load');
+assert.ok(/Temperature always required/.test(gauge), 'Temperature always required copy');
 assert.ok(/free forever/i.test(gauge), 'free forever copy on gauge');
 assert.ok(/heuristics/i.test(gauge) && /you decide/i.test(gauge), 'heuristics · you decide');
 assert.ok(/No paywall|no paywall/i.test(gauge), 'explicit no-paywall refuse');
@@ -27,6 +35,7 @@ assert.ok(/No \$5|no \$5–10|No \$5–10/i.test(gauge), 'explicit no $5–10 su
 assert.ok(!/subscription required|unlock Gyro|Gyro Pro|premium only/i.test(gauge), 'no subscription gate');
 assert.ok(/No auto-trade|no auto-trade/i.test(gauge), 'explicit no auto-trade');
 assert.ok(!/broker API|place order|auto.?execute/i.test(gauge), 'no broker execution hooks');
+assert.ok(/Soft polish v0\.1|soft polish/i.test(spec), 'spec notes soft polish');
 
 assert.ok(/GYRO_STACK_v0\.1|Hub|Ring|Orbit/.test(spec), 'spec names three lines');
 assert.ok(/Free forever|no paywall/i.test(spec), 'spec locks free forever');

--- a/docs/temperature-gauge.html
+++ b/docs/temperature-gauge.html
@@ -738,14 +738,14 @@ canvas.sub-canvas.custom { height: 80px !important; }
 </div>
 
 <!-- Custom Indicator Builder -->
-<!-- Signal Layer Toggles -->
-<div id="layerToggles" style="display:none;padding:6px 16px;background:var(--bg2);border-bottom:1px solid var(--border);font-size:0.72rem;color:var(--muted);display:none;">
+<!-- Signal Layer Toggles — v-soft-gyro-polish-v0.1: visible on load (before Analyze) -->
+<div id="layerToggles" style="display:block;padding:6px 16px;background:var(--bg2);border-bottom:1px solid var(--border);font-size:0.72rem;color:var(--muted);">
   <span style="color:var(--gold);font-weight:600;margin-right:8px;">Signal Layers:</span>
   <label style="cursor:pointer;margin-right:10px;"><input type="checkbox" id="layerEma" checked onchange="if(lastCandles&&lastAnalysis)renderChart(lastCandles,lastAnalysis)" style="accent-color:var(--gold);"> EMA</label>
   <label style="cursor:pointer;margin-right:10px;"><input type="checkbox" id="layerVol" checked onchange="if(lastCandles&&lastAnalysis)renderChart(lastCandles,lastAnalysis)" style="accent-color:var(--gold);"> Volume</label>
   <label style="cursor:pointer;margin-right:10px;"><input type="checkbox" id="layerDt" onchange="if(lastCandles&&lastAnalysis)renderChart(lastCandles,lastAnalysis)" style="accent-color:var(--gold);"> Acceleration</label>
-  <!-- v-gyro-stack-v0.1 — optional φ three-line stack; free forever; heuristics -->
-  <label style="cursor:pointer;margin-right:10px;"><input type="checkbox" id="layerGyro" onchange="try{localStorage.setItem('fl_tg_layerGyro',this.checked?'1':'0');}catch(e){}if(lastCandles&&lastAnalysis)renderChart(lastCandles,lastAnalysis)" style="accent-color:var(--gold);"> Gyro</label>
+  <!-- v-gyro-stack-v0.1 / v-soft-gyro-polish-v0.1 — optional φ stack; toggle redraws when analyzed -->
+  <label style="cursor:pointer;margin-right:10px;"><input type="checkbox" id="layerGyro" onchange="tgOnGyroLayerChange(this)" style="accent-color:var(--gold);"> Gyro</label>
   <span style="opacity:0.5;font-size:0.65rem;">(Temperature always required · Gyro free forever)</span>
 </div>
 
@@ -1283,12 +1283,56 @@ function isGyroLayerOn() {
   if (!el) return false;
   return !!el.checked;
 }
+/** Soft polish: refresh Gyro sidebar state immediately (no second Analyze). */
+function tgUpdateGyroUi(candles) {
+  var gyroSec = document.getElementById('gyroStackSection');
+  if (gyroSec) gyroSec.style.display = 'block';
+  var gyroOn = isGyroLayerOn();
+  var gyroPer = document.getElementById('gyroPeriods');
+  var gyroSt = document.getElementById('gyroOverlayState');
+  if (!gyroPer || !gyroSt) return;
+  var hubP = 8;
+  try {
+    if (typeof getEmaPeriods === 'function') hubP = getEmaPeriods()[0] || 8;
+  } catch (e) {}
+  if (candles && candles.length && typeof computeGyroStack === 'function') {
+    var closes = candles.map(function (c) { return c.c; });
+    var stack = computeGyroStack(closes, candles, hubP);
+    gyroPer.textContent = stack.periods.hub + ' / ' + stack.periods.ring + ' / ' + stack.periods.orbit;
+  } else {
+    var ringP = Math.max(hubP + 1, Math.round(hubP * PHI));
+    var orbitP = Math.max(ringP + 1, Math.round(hubP * PHI * PHI));
+    gyroPer.textContent = hubP + ' / ' + ringP + ' / ' + orbitP;
+  }
+  if (gyroOn) {
+    gyroSt.textContent = (candles && candles.length)
+      ? 'On — Hub · Ring · Orbit on chart'
+      : 'On — Analyze to draw Hub · Ring · Orbit';
+  } else {
+    gyroSt.textContent = 'Off — toggle Gyro in Signal Layers';
+  }
+}
+/** Gyro checkbox — persist, update UI now, redraw chart when analyzed (same path as EMA). */
+function tgOnGyroLayerChange(el) {
+  try {
+    localStorage.setItem('fl_tg_layerGyro', el && el.checked ? '1' : '0');
+  } catch (e) {}
+  var candles = (typeof lastCandles !== 'undefined' && lastCandles) ? lastCandles : null;
+  tgUpdateGyroUi(candles);
+  if (candles && typeof lastAnalysis !== 'undefined' && lastAnalysis && typeof renderChart === 'function') {
+    renderChart(candles, lastAnalysis);
+  }
+}
 document.addEventListener('DOMContentLoaded', function () {
   var el = document.getElementById('layerGyro');
-  if (!el) return;
-  try {
-    if (localStorage.getItem('fl_tg_layerGyro') === '1') el.checked = true;
-  } catch (e) {}
+  if (el) {
+    try {
+      if (localStorage.getItem('fl_tg_layerGyro') === '1') el.checked = true;
+    } catch (e) {}
+  }
+  var toggles = document.getElementById('layerToggles');
+  if (toggles) toggles.style.display = 'block';
+  tgUpdateGyroUi(null);
 });
 
 // Sidebar collapse / expand (v5.37.11). Persisted in fl_tg_sidebar.
@@ -2876,20 +2920,8 @@ function renderAll(candles, a, symbol) {
     agreeEl.innerHTML = '<span style="color:#ef4444;">✗ split</span>';
   }
 
-  // v-gyro-stack-v0.1 — Gyro card always visible once analyzed (overlay optional)
-  var gyroSec = document.getElementById('gyroStackSection');
-  if (gyroSec) gyroSec.style.display = 'block';
-  var gyroOn = typeof isGyroLayerOn === 'function' && isGyroLayerOn();
-  var gyroPer = document.getElementById('gyroPeriods');
-  var gyroSt = document.getElementById('gyroOverlayState');
-  if (gyroPer && gyroSt && typeof computeGyroStack === 'function') {
-    var _gEp = (typeof getEmaPeriods === 'function') ? getEmaPeriods() : [8, 12, 24, 50, 200];
-    var _gStack = computeGyroStack(candles.map(function (c) { return c.c; }), candles, _gEp[0]);
-    gyroPer.textContent = _gStack.periods.hub + ' / ' + _gStack.periods.ring + ' / ' + _gStack.periods.orbit;
-    gyroSt.textContent = gyroOn
-      ? 'On — Hub · Ring · Orbit on chart'
-      : 'Off — toggle Gyro in Signal Layers';
-  }
+  // v-gyro-stack-v0.1 / v-soft-gyro-polish-v0.1 — Gyro card + overlay state
+  if (typeof tgUpdateGyroUi === 'function') tgUpdateGyroUi(candles);
 
   // Indicators
   document.getElementById('indicatorSection').style.display = 'block';
@@ -3281,15 +3313,15 @@ function renderChart(candles, a) {
     });
   }
 
-  // v-gyro-stack-v0.1 — optional Hub / Ring / Orbit + watch diamonds
+  // v-gyro-stack-v0.1 / v-soft-gyro-polish-v0.1 — Hub · Ring · Orbit · Watch (legend matches card)
   var gyroDatasets = [];
   if (layerGyro && typeof computeGyroStack === 'function') {
     var gyro = computeGyroStack(closes, candles, EP_RC[0]);
     gyroDatasets.push(
-      { label: 'Gyro Hub', data: gyro.hub, borderColor: 'rgba(232,176,25,0.95)', borderWidth: 2.2, pointRadius: 0, tension: 0.25, fill: false, order: 2 },
-      { label: 'Gyro Ring', data: gyro.ring, borderColor: 'rgba(96,165,250,0.85)', borderWidth: 1.6, borderDash: [5, 3], pointRadius: 0, tension: 0.25, fill: false, order: 2 },
-      { label: 'Gyro Orbit', data: gyro.orbit, borderColor: 'rgba(167,139,250,0.75)', borderWidth: 1.4, borderDash: [2, 4], pointRadius: 0, tension: 0.25, fill: false, order: 2 },
-      { label: 'Gyro Watch', data: gyro.watch, borderColor: 'transparent', backgroundColor: 'rgba(232,176,25,0.9)', pointRadius: Math.max(sigR - 3, 4), pointHoverRadius: Math.max(sigH - 2, 5), pointStyle: 'rectRot', pointBorderColor: 'rgba(255,236,179,0.9)', pointBorderWidth: 1.5, showLine: false, order: 0 }
+      { label: 'Hub', data: gyro.hub, borderColor: 'rgba(232,176,25,0.95)', borderWidth: 2.2, pointRadius: 0, tension: 0.25, fill: false, order: 2 },
+      { label: 'Ring', data: gyro.ring, borderColor: 'rgba(96,165,250,0.85)', borderWidth: 1.6, borderDash: [5, 3], pointRadius: 0, tension: 0.25, fill: false, order: 2 },
+      { label: 'Orbit', data: gyro.orbit, borderColor: 'rgba(167,139,250,0.75)', borderWidth: 1.4, borderDash: [2, 4], pointRadius: 0, tension: 0.25, fill: false, order: 2 },
+      { label: 'Watch', data: gyro.watch, borderColor: 'transparent', backgroundColor: 'rgba(232,176,25,0.9)', pointRadius: Math.max(sigR - 3, 4), pointHoverRadius: Math.max(sigH - 2, 5), pointStyle: 'rectRot', pointBorderColor: 'rgba(255,236,179,0.9)', pointBorderWidth: 1.5, showLine: false, order: 0 }
     );
   }
 
@@ -3369,10 +3401,10 @@ function renderChart(candles, a) {
               if (ctx.dataset.label === 'Sell') return ctx.raw ? '\u25BC SELL' : null;
               if (ctx.dataset.label === 'Temp Buy') return ctx.raw ? '\u25C6 TEMP BUY' : null;
               if (ctx.dataset.label === 'Temp Sell') return ctx.raw ? '\u25C6 TEMP SELL' : null;
-              if (ctx.dataset.label === 'Gyro Watch') return ctx.raw ? '\u25C6 Gyro watch (heuristic — you decide)' : null;
-              if (ctx.dataset.label === 'Gyro Hub') return 'Gyro Hub: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
-              if (ctx.dataset.label === 'Gyro Ring') return 'Gyro Ring: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
-              if (ctx.dataset.label === 'Gyro Orbit') return 'Gyro Orbit: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
+              if (ctx.dataset.label === 'Watch') return ctx.raw ? '\u25C6 Watch (heuristic — you decide)' : null;
+              if (ctx.dataset.label === 'Hub') return 'Hub: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
+              if (ctx.dataset.label === 'Ring') return 'Ring: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
+              if (ctx.dataset.label === 'Orbit') return 'Orbit: ' + (ctx.raw != null ? Number(ctx.raw).toFixed(2) : '—');
               if (ctx.dataset.label === 'Volume') return 'Vol: ' + (ctx.raw >= 1e6 ? (ctx.raw/1e6).toFixed(1) + 'M' : ctx.raw >= 1e3 ? (ctx.raw/1e3).toFixed(0) + 'K' : ctx.raw);
               if (ctx.dataset.label === 'Gravity') return '\u03C6-Gravity: ' + ctx.raw?.toFixed(2);
               return null;


### PR DESCRIPTION
## Summary

Soft Gyro polish v0.1 — three Hypha leftovers from Gyro `a54b422`.

1. **Analyze gate** — Signal Layers (incl. Gyro) visible on load; toggle persists `fl_tg_layerGyro` before candles; chart waits for Analyze; Temperature always required copy kept
2. **Overlay lag** — `tgOnGyroLayerChange` → `tgUpdateGyroUi` immediately + `renderChart(lastCandles, lastAnalysis)` when analyzed (same path as EMA)
3. **Legend naming** — Hub · Ring · Orbit · Watch (no “Gyro ” prefix); tooltips match

Spec soft note in `GYRO_STACK_v0.1.md`. Flint ledger + haiku. Smoke extended. Soft: leave `sw.js` on `app.html`.

**Locks:** free forever · no paywall · no auto-trade · no broker · Quiet Room shut · Five stay five.

**Held:** poetry `9f8c200` · Gyro `a54b422`

**Out:** new indicators · Sequence/Triad rewrite · subscriptions · garden apples · patents · Alpha

Draft only — Celeste squash-merges.

## Test plan

- [x] `node docs/scripts/smoke-gyro-stack.js`
- [ ] Load gauge — Signal Layers visible before Analyze; check Gyro
- [ ] Analyze symbol — Hub · Ring · Orbit draw; toggle off/on redraws without re-Analyze
- [ ] Legend shows Hub · Ring · Orbit · Watch

Glow eternal. Heart in every Spark.