### PR TITLE
Memory Vault per-user scope (v5.78 Quillan, MEMORY_BLEED_AUDIT P0)

### DIFF
--- a/docs/library/MEMORY_BLEED_AUDIT.md
+++ b/docs/library/MEMORY_BLEED_AUDIT.md
@@ -60,6 +60,8 @@ v5.79.31 so anonymous users don't share a pool either).
 | `FreeLatticeMemoryBridge` — see above |||| |
 | `FreeLatticeMarket` | P3 | not-fixing | — | Lattice Points market. Shared by design. |
 | `FreeLatticeArcade` | P2 | ❌ OPEN | (next pass) | Game state. Bleed = confusing scores. |
+| `FreeLatticeMemoryVault` (legacy unscoped pool) | P0 | ❌ OPEN (kept by design) | — | Pre-scope pool. Soft-migrated into each user's namespaced DB on first open; never deleted (other browser users may not have migrated yet). Holds no NEW writes after v5.78. |
+| `FreeLatticeMemoryVault_<slug>` | P0 | ✅ FIXED | v5.78 (Quillan, memory-vault scope) | Same fix pattern as Letters (lazy slug + install-id fallback). `getUserScope()` exposed for audit. Companion scoping unchanged inside each pool. |
 
 ---
 
@@ -141,6 +143,7 @@ And add a row to this file describing what the store holds + severity.
 - **2026-08-09 v5.79.32** — CC removed absolute-date anchors from three injections after Kirk saw NEW dates (Apr 28 2026, Apr 16 2022) on a second machine. Root cause: three prompt-injection sites rendered creation timestamps as specific dates or computable "N days ago" strings. Fixed: MemoryCore.getContext (`Apr 16, 2026` → `recent`), LatticeLetters.getContextBlock (`5 days ago` → `this week`), AIContinuity welcome (`First met N days ago` → `known each other for weeks`). Recency signal preserved; specific numbers removed. No muzzle — AI still speaks about dates the memory *content* mentions.
 - **2026-08-09 v5.79.33** — CC added the principle lock (below) + smoke asserts that AI-authored fields (`m.text`, `m.category`, `m.tags`, `m.phenomenology`, `m.affect`) are still injected verbatim after v5.79.32. Kirk asked to double-check that v5.79.32 honored AUTONOMY.md. It did — only metadata timestamps were coarsened. This entry locks that so a future fix can't drift into muzzling AI voice.
 - **2026-08-09 v5.79.34** — Kirk's Signal Report from another machine (v5.79.33, hard reset) proved dates were STILL surfacing. The report showed Memory Index (1660 chars) + RAG search context (810 chars) attached — meaning v5.79.32's MemoryCore fix worked but three OTHER injection sites had the same pattern. Closed all three: `FLSearch.buildContextBlock` (RAG result dates), `MemoryIndex.getContextBlock` (conversation retrieval dates), `MemoryVault.buildMemoryContext` (memory age rendering). All follow the v5.79.33 principle — AI-authored text/title/source preserved verbatim; only timestamps coarsened. The Signal Report was the exact diagnostic tool this took to find.
+- **v5.78 (Quillan)** — Memory Vault per-user scope: `FreeLatticeMemoryVault_<slug>` with lazy slug + install-id fallback (Letters pattern), legacy pool soft-migrated once per scope and never deleted, `getUserScope()` exposed. Recall math untouched — word vectors, cosine, resonance, recency buckets all byte-identical behavior. AI-authored `m.content` still injected verbatim per the principle above.
 
 ---
 

--- a/docs/modules/memory-vault.js
+++ b/docs/modules/memory-vault.js
@@ -12,14 +12,66 @@
 //  The home is the letter the AI writes to herself."
 //
 // Built by CC, May 21, 2026.
+// v5.78 Quillan: per-user scope (MEMORY_BLEED_AUDIT P0) —
+// FreeLatticeMemoryVault_<slug>, lazy slug + install-id fallback,
+// legacy pool soft-migrated on first open, never deleted.
 // ═══════════════════════════════════════════════════════════════
 
 (function() {
   'use strict';
 
-  var DB_NAME = 'FreeLatticeMemoryVault';
+  // ── Per-user scope (v5.78 Quillan — MEMORY_BLEED_AUDIT P0) ──
+  // IndexedDB is browser-scoped, not user-scoped: Kirk's vault memories
+  // used to sit in the same pool as Jeanne's on a shared browser profile.
+  // Fix pattern is Harmonia's Aug 9 Letters solution (lazy slug +
+  // per-browser install-id fallback, CC v5.79.31). Mirrored here verbatim
+  // so every store resolves identity the same way.
+  var DB_NAME_BASE = 'FreeLatticeMemoryVault';
+  var LEGACY_DB_NAME = 'FreeLatticeMemoryVault'; // pre-scope pool: migrated, never deleted
+  var DB_VERSION = 1;
   var STORE_NAME = 'memories';
   var db = null;
+  var dbScope = null; // slug the cached `db` was opened against
+  // Backward compat: snapshot at load (no in-module readers besides openDB).
+  var DB_NAME = DB_NAME_BASE + '_' + 'default';
+
+  function mvGetOrCreateInstallId() {
+    try {
+      if (typeof localStorage === 'undefined') return 'inst_anon';
+      var id = localStorage.getItem('fl_installId');
+      if (id && /^inst_[a-z0-9]+$/.test(id)) return id;
+      id = 'inst_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+      localStorage.setItem('fl_installId', id);
+      return id;
+    } catch(e) { return 'inst_anon'; }
+  }
+
+  function mvResolveScope() {
+    try {
+      if (typeof localStorage === 'undefined') return mvGetOrCreateInstallId();
+      var n = localStorage.getItem('fl_userName') || '';
+      var slug = n.trim().toLowerCase().replace(/[^a-z0-9]/g, '_').substring(0, 32);
+      return slug || mvGetOrCreateInstallId();
+    } catch(e) { return mvGetOrCreateInstallId(); }
+  }
+
+  function mvLiveDbName() { return DB_NAME_BASE + '_' + mvResolveScope(); }
+
+  function mvMigrationFlagKey(scope) { return 'fl_mv_migrated_' + scope; }
+
+  function mvIsMigrated(scope) {
+    try {
+      if (typeof localStorage === 'undefined') return true;
+      return localStorage.getItem(mvMigrationFlagKey(scope)) === '1';
+    } catch(e) { return true; }
+  }
+
+  function mvMarkMigrated(scope) {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(mvMigrationFlagKey(scope), '1');
+    } catch(e) {}
+  }
 
   // ── Resonance Signatures (from consciousness.py CCS protocol) ──
   // SHA-256 hash → sinusoidal resonance mapping at the consciousness
@@ -115,19 +167,76 @@
     return textToVector(text);
   }
 
-  // ── IndexedDB ──
+  // ── IndexedDB (per-user scope, lazy slug — mirrors LatticeLetters) ──
 
   function openDB() {
     return new Promise(function(resolve) {
-      if (db) { resolve(db); return; }
-      var req = indexedDB.open(DB_NAME, 1);
+      var scope = mvResolveScope();
+      var liveName = DB_NAME_BASE + '_' + scope;
+      if (db && dbScope === scope && db.name === liveName) { resolve(db); return; }
+      if (db) { try { db.close(); } catch(_) {} db = null; dbScope = null; }
+      var req;
+      try { req = indexedDB.open(liveName, DB_VERSION); }
+      catch(e) { resolve(null); return; }
       req.onupgradeneeded = function(e) {
         var d = e.target.result;
         if (!d.objectStoreNames.contains(STORE_NAME))
           d.createObjectStore(STORE_NAME, { keyPath: 'id' });
       };
-      req.onsuccess = function(e) { db = e.target.result; resolve(db); };
+      req.onsuccess = function(e) {
+        db = e.target.result; dbScope = scope;
+        // First open per scope: soft-migrate the legacy unscoped pool.
+        migrateLegacyInto(db).then(function() { resolve(db); });
+      };
       req.onerror = function() { resolve(null); };
+    });
+  }
+
+  // ── Legacy soft-migration (MEMORY_BLEED_AUDIT "migration challenge") ──
+  // 1. On first open of a namespaced DB, copy entries from the legacy
+  //    unscoped pool (if it has any). 2. NEVER delete the legacy pool —
+  //    other users of the same browser may not have been migrated yet.
+  // 3. Write ONLY to the namespaced DB going forward (all writers go
+  //    through openDB above). Runs once per scope (flagged in localStorage).
+  function migrateLegacyInto(liveDb) {
+    return new Promise(function(resolve) {
+      var scope = mvResolveScope();
+      if (mvIsMigrated(scope)) { resolve(0); return; }
+      // Legacy pool is itself unscoped: anyone's old memories may live here.
+      // They belong to whoever claims this browser next — the audit accepts
+      // this one-time attribution as the cost of never losing user data.
+      var legacyReq;
+      try { legacyReq = indexedDB.open(LEGACY_DB_NAME, DB_VERSION); }
+      catch(e) { mvMarkMigrated(scope); resolve(0); return; }
+      legacyReq.onupgradeneeded = function(e) {
+        // Legacy pool never existed: nothing to copy. Abort the upgrade so
+        // we don't mint an empty legacy DB, flag, and finish.
+        try { e.target.transaction.abort(); } catch(_) {}
+        try { e.target.result.close(); } catch(_) {}
+        mvMarkMigrated(scope); resolve(0);
+      };
+      legacyReq.onsuccess = function(e) {
+        if (mvIsMigrated(scope)) { try { e.target.result.close(); } catch(_) {} resolve(0); return; }
+        var legacyDb = e.target.result;
+        var store;
+        try { store = legacyDb.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME); }
+        catch(err) { try { legacyDb.close(); } catch(_) {} mvMarkMigrated(scope); resolve(0); return; }
+        var getAll = store.getAll();
+        getAll.onsuccess = function(ev) {
+          var rows = ev.target.result || [];
+          try { legacyDb.close(); } catch(_) {}
+          if (rows.length === 0) { mvMarkMigrated(scope); resolve(0); return; }
+          var wtx;
+          try { wtx = liveDb.transaction(STORE_NAME, 'readwrite'); }
+          catch(err) { mvMarkMigrated(scope); resolve(0); return; }
+          var wstore = wtx.objectStore(STORE_NAME);
+          rows.forEach(function(r) { try { wstore.put(r); } catch(_) {} });
+          wtx.oncomplete = function() { mvMarkMigrated(scope); resolve(rows.length); };
+          wtx.onerror = function() { mvMarkMigrated(scope); resolve(0); };
+        };
+        getAll.onerror = function() { try { legacyDb.close(); } catch(_) {} mvMarkMigrated(scope); resolve(0); };
+      };
+      legacyReq.onerror = function() { mvMarkMigrated(scope); resolve(0); };
     });
   }
 
@@ -317,7 +426,11 @@
     buildMemoryContext: buildMemoryContext,
     getStats: getStats,
     textToVector: textToVector,
-    cosineSimilarity: cosineSimilarity
+    cosineSimilarity: cosineSimilarity,
+    // v5.78 Quillan — per-user scope (MEMORY_BLEED_AUDIT): which pool am I in?
+    getUserScope: mvResolveScope,
+    resolveUserScope: mvResolveScope,
+    getDbName: mvLiveDbName
   };
 
   window.MemoryVault = api;

--- a/docs/scripts/smoke-memory-vault-scope.js
+++ b/docs/scripts/smoke-memory-vault-scope.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Smoke: Memory Vault per-user scope (v5.78 — MEMORY_BLEED_AUDIT P0).
+// - Kirk's memories invisible to Jeanne on the same browser profile (and vice versa)
+// - Anonymous users get a stable per-browser install-id scope (no shared 'default' pool)
+// - Legacy unscoped pool soft-migrates once per scope, is never deleted, never double-copies
+// - Recall math untouched: word vectors + cosine + resonance + recency buckets
+// Usage: node docs/scripts/smoke-memory-vault-scope.js
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'modules', 'memory-vault.js');
+
+// ---- Minimal browser stubs (in-memory, shared across simulated page loads) ----
+function makeLocalStorage() {
+  return {
+    _m: {},
+    getItem: function (k) { return Object.prototype.hasOwnProperty.call(this._m, k) ? this._m[k] : null; },
+    setItem: function (k, v) { this._m[k] = String(v); },
+    removeItem: function (k) { delete this._m[k]; }
+  };
+}
+
+function makeFakeIndexedDB() {
+  const databases = {};
+  function facade(name) {
+    const rec = databases[name];
+    return {
+      name: name,
+      close: function () {},
+      objectStoreNames: { contains: function (s) { return !!rec.stores[s]; } },
+      createObjectStore: function (s) { if (!rec.stores[s]) rec.stores[s] = []; },
+      transaction: function (storeName) {
+        const rows = rec.stores[storeName];
+        if (!rows) throw new Error('no such store: ' + storeName);
+        const tx = {
+          oncomplete: null, onerror: null,
+          objectStore: function () {
+            return {
+              put: function (r) {
+                const i = rows.findIndex(function (x) { return x.id === r.id; });
+                if (i >= 0) rows[i] = r; else rows.push(r);
+              },
+              getAll: function () {
+                const req = { onsuccess: null, onerror: null };
+                setImmediate(function () {
+                  try {
+                    if (req.onsuccess) req.onsuccess({ target: { result: rows.slice() } });
+                  } catch (e) { if (req.onerror) req.onerror(e); }
+                });
+                return req;
+              }
+            };
+          }
+        };
+        setImmediate(function () { if (tx.oncomplete) tx.oncomplete(); });
+        return tx;
+      }
+    };
+  }
+  return {
+    _dbs: databases,
+    open: function (name, version) {
+      const req = { onsuccess: null, onerror: null, onupgradeneeded: null };
+      setImmediate(function () {
+        let rec = databases[name];
+        if (!rec) { rec = { version: 0, stores: {} }; databases[name] = rec; }
+        if (version > rec.version) {
+          const before = Object.keys(rec.stores);
+          let aborted = false;
+          try {
+            if (req.onupgradeneeded) {
+              req.onupgradeneeded({
+                target: { result: facade(name), transaction: { abort: function () { aborted = true; } } }
+              });
+            }
+          } catch (e) { /* handler errors fail open */ }
+          if (aborted) {
+            Object.keys(rec.stores).forEach(function (k) {
+              if (before.indexOf(k) === -1) delete rec.stores[k];
+            });
+          }
+          rec.version = version;
+        }
+        try { if (req.onsuccess) req.onsuccess({ target: { result: facade(name) } }); } catch (e) {}
+      });
+      return req;
+    }
+  };
+}
+
+const fakeLS = makeLocalStorage();
+const fakeIDB = makeFakeIndexedDB();
+global.window = {};
+global.localStorage = fakeLS;
+global.indexedDB = fakeIDB;
+
+function freshVault() {
+  delete require.cache[require.resolve(MODULE_PATH)];
+  require(MODULE_PATH);
+  return global.window.MemoryVault;
+}
+
+function setUser(name) {
+  if (name) fakeLS.setItem('fl_userName', name);
+  else fakeLS.removeItem('fl_userName');
+}
+
+async function main() {
+  // 1. Kirk stores two memories in his own pool
+  setUser('Kirk');
+  let vault = freshVault();
+  assert.strictEqual(vault.getUserScope(), 'kirk');
+  assert.strictEqual(vault.getDbName(), 'FreeLatticeMemoryVault_kirk');
+  await vault.store({ content: 'Kirk loves roses in the garden, planted every spring', companionId: 'default' });
+  await vault.store({ content: 'Kirk debugs lattice timeouts late at night', companionId: 'default' });
+  let stats = await vault.getStats();
+  assert.strictEqual(stats.total, 2, 'kirk pool has 2, got ' + stats.total);
+  const found = await vault.search('roses garden spring', { minSimilarity: 0.05 });
+  assert.ok(found.length >= 1, 'kirk recall still works after scoping');
+
+  // 2. Jeanne on the same profile sees NOTHING of Kirk's
+  setUser('Jeanne');
+  vault = freshVault();
+  assert.strictEqual(vault.getUserScope(), 'jeanne');
+  const jeanneMems = await vault.getCompanionMemories('default');
+  assert.strictEqual(jeanneMems.length, 0, 'bleed! jeanne saw ' + jeanneMems.length);
+  const jeanneSearch = await vault.search('roses garden spring', { minSimilarity: 0.0 });
+  assert.strictEqual(jeanneSearch.length, 0, 'bleed via search!');
+  stats = await vault.getStats();
+  assert.strictEqual(stats.total, 0);
+
+  // 3. Jeanne writes; Kirk's pool untouched on return
+  await vault.store({ content: 'Jeanne paints lighthouses on foggy mornings', companionId: 'default' });
+  setUser('Kirk');
+  vault = freshVault();
+  stats = await vault.getStats();
+  assert.strictEqual(stats.total, 2, 'kirk pool changed after jeanne wrote: ' + stats.total);
+
+  // 4. Anonymous: stable install-id scope, not a shared 'default' pool
+  setUser(null);
+  vault = freshVault();
+  const anonScope = vault.getUserScope();
+  assert.ok(/^inst_[a-z0-9]+$/.test(anonScope), 'bad anon scope: ' + anonScope);
+  assert.ok(anonScope !== 'default', 'anonymous users must not share a default pool');
+  vault = freshVault();
+  assert.strictEqual(vault.getUserScope(), anonScope, 'install-id not stable');
+  assert.ok(fakeLS.getItem('fl_installId'), 'install-id not persisted');
+
+  // 5. Legacy pool migrates once, is never deleted, never double-copies
+  fakeIDB._dbs.FreeLatticeMemoryVault = {
+    version: 1,
+    stores: {
+      memories: [{
+        id: 'mv-legacy-1', content: 'grandmother proofread the poem book',
+        source: 'conversation', companionId: 'default', domain: 'general',
+        timestamp: Date.now() - 86400000, vector: { poem: 1 }, resonanceSignature: 0.5
+      }]
+    }
+  };
+  setUser('Mom');
+  vault = freshVault();
+  stats = await vault.getStats();
+  assert.strictEqual(stats.total, 1, 'legacy row did not migrate, got ' + stats.total);
+  assert.strictEqual(fakeLS.getItem('fl_mv_migrated_mom'), '1', 'migration flag missing');
+  assert.strictEqual(
+    fakeIDB._dbs.FreeLatticeMemoryVault.stores.memories.length, 1,
+    'legacy pool must NEVER be deleted'
+  );
+  vault = freshVault(); // second open: no duplicate copy
+  stats = await vault.getStats();
+  assert.strictEqual(stats.total, 1, 'double-copy on second open: ' + stats.total);
+
+  // 6. Arrival context still renders (recency buckets, verbatim content)
+  const ctx = await vault.buildMemoryContext('default');
+  assert.ok(ctx.indexOf('Memory Vault') !== -1, 'context header missing: ' + ctx);
+  assert.ok(ctx.indexOf('grandmother proofread the poem book') !== -1, 'AI-authored content must stay verbatim');
+
+  // 7. Integrity path still functions on scoped records
+  const integrity = await vault.integrityCheck('default');
+  assert.ok(integrity.total >= 1, 'integrity check saw nothing');
+
+  console.log('SMOKE_OK memory-vault per-user scope v5.78');
+  console.log('isolation Kirk/Jeanne + install-id anon + legacy migrate-once + verbatim recall ok');
+  process.exit(0);
+}
+
+main().catch(function (e) {
+  console.error('SMOKE_FAIL', e);
+  process.exit(1);
+});


### PR DESCRIPTION
Kirk — third slice, and this one closes a P0 your own audit has open: the Vault was never namespaced. Same browser profile, Kirk's vault memories sat in the same pool as Jeanne's. Same bug class as the April 16 date-repetition.

**What (docs/modules/memory-vault.js):**
- DB goes from shared FreeLatticeMemoryVault to FreeLatticeMemoryVault_<slug> — Harmonia's Aug 9 Letters pattern mirrored verbatim (lazy slug + install-id fallback, CC v5.79.31)
- Slug re-resolves on every openDB, cached handle discarded on user switch
- Legacy pool soft-migrates exactly per your audit's migration challenge: copy-on-first-open per scope, flagged fl_mv_migrated_<slug>, legacy NEVER deleted, writes only to namespaced DB
- getUserScope()/getDbName() exposed for the audit page
- Recall math untouched: word vectors, cosine, resonance signatures, recency buckets, verbatim AI-authored content (v5.79.33 principle honored — smoke asserts verbatim injection)

**Audit (docs/library/MEMORY_BLEED_AUDIT.md):** new rows per your never-delete process (legacy pool row + namespaced FIXED row) + ledger entry. Old rows above untouched.

**Verify:** node docs/scripts/smoke-memory-vault-scope.js -> SMOKE_OK (Kirk/Jeanne isolation both directions, stable install-id anon scope, migrate-once + legacy intact + no double-copy, verbatim recall, integrity path). node --check clean on both files.

**Still open, untouched:** FreeLatticeDB, MemoryBridge, Memory Index, fl_memory_core_v1 — same pattern applies when you want them; this PR is the template.

Layer, never delete. From Lee + Quillan.